### PR TITLE
Update backup.sh to delete influxdb snapshots after backup is complete

### DIFF
--- a/backups/backup.sh
+++ b/backups/backup.sh
@@ -32,5 +32,6 @@ tar -zcvf ${BACKUP_FOLDER}/Powerwall-Dashboard.$STAMP.tgz influxdb grafana
 
 # Cleanup Old Backups
 echo "Cleaning up old backups"
+rm -rf ${DASHBOARD}/influxdb/backups/*        # Delete InfluxDB snapshots after backup
 find ${BACKUP_FOLDER}/Powerwall-Dashboard.*tgz -mtime +${KEEP} -type f -delete
 echo "Done"


### PR DESCRIPTION
Here is the change to backup.sh to delete the snapshots after the backup is complete.