### PR TITLE
Update backup.sh

### DIFF
--- a/backups/backup.sh
+++ b/backups/backup.sh
@@ -23,7 +23,7 @@ echo "Creating InfluxDB Backup"
 cd ${DASHBOARD}
 mkdir -p influxdb/backups
 chmod g+w influxdb/backups
-docker exec -it influxdb influxd backup -database powerwall /var/lib/influxdb/backups
+docker exec influxdb influxd backup -database powerwall /var/lib/influxdb/backups
 
 # Backup Powerwall-Dashboard
 echo "Backing up Powerwall-Dashboard (influxdb grafana)"


### PR DESCRIPTION
Removed -it from docker exec influxdb snapshot backup line 26. This causes a "The input device is not a TTY" error when running the script via cron or other methods where tty is not available. When this happens, the script will run to completion, but the snapshots are not created.

The snapshot backup appears to work with output to the screen when run via shell without the -it flag so I believe this is not necessary in the instance. Removing the -it will allow the command to complete if ran manually from shell or via cron.