### PR TITLE
Remove dew_point from API service of Weather411

### DIFF
--- a/weather/server.py
+++ b/weather/server.py
@@ -336,8 +336,7 @@ class handler(BaseHTTPRequestHandler):
             result["temperature"] = weather["temperature"]
             message = json.dumps(result)            
         elif self.path in ["/temperature","/humidity","/pressure","/visibility",
-                           "/clouds","/sunrise","/sunset","/feels_like",
-                           "/dew_point"]:
+                           "/clouds","/sunrise","/sunset","/feels_like"]:
             i = self.path.split("/")[1]
             result[i] = weather[i]
             message = json.dumps(result)


### PR DESCRIPTION
Remove `dew_point` from API service of Weather411 as the data is not available with "weather" API call to OpenWeatherMap.