### PR TITLE
Fix missing space in if statement

### DIFF
--- a/weather.sh
+++ b/weather.sh
@@ -107,7 +107,7 @@ if [ ! -f ${CONF_FILE} ]; then
         exit 0
     fi
     read -p 'Enter Longitude: ' LON
-    if [-z "${LON}" ]; then 
+    if [ -z "${LON}" ]; then 
         echo "ERROR: Valid coordinates are required. Exiting now."
         exit 0
     fi


### PR DESCRIPTION
Fix missing space in if statement which causes an error during script execution: `./weather.sh: line 110: [-z: command not found`