### PR TITLE
Eliminate horizontal scrollbars on iPhone.

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -962,7 +962,7 @@
       "id": 13,
       "links": [],
       "options": {
-        "content": "<div style=\"text-align: center\">\n<iframe id=\"frame\" src=\"/public/img/grafana_icon.svg\" width=\"400\" height=\"300\" frameBorder=\"0\">No</iframe>\n<script>\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\nconsole.log(pwurl);\ndocument.getElementById('frame').src = pwurl;\n</script>\n</div>",
+        "content": "<div style=\"text-align: center\">\n<iframe id=\"frame\" src=\"/public/img/grafana_icon.svg\" width=\"100%\" height=\"300\" frameBorder=\"0\">No</iframe>\n<script>\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\nconsole.log(pwurl);\ndocument.getElementById('frame').src = pwurl;\n</script>\n</div>",
         "mode": "html"
       },
       "pluginVersion": "9.1.2",


### PR DESCRIPTION
Problem: When trying to scroll through the dashboard on an iPhone, the iframe will scroll horizontally which is not desirable. This seems to eliminate the horizontal scroll bar on iPhone Safari browser for the animation iframe. It also centers the text above the grid and home icons.

I tested with my iPhone and the Chromium Edge browser on my Windows 11 PC. I do not see any negative effects. I am no longer able to scroll the iframe horizontally with safari on my iphone which was the desired result. I also notice the text is now correctly centered above the icons when viewed from Edge. It renders in Grafana like it does when going to port 8675 from the browser. I am on firmware 22.26.2 8cd8cac4 now. It seemed like the horizontal scrollbars showed up after the "foxtrot" update. Maybe this will make the iframe more tolerant to future changes from Tesla?

