### PR TITLE
Add tool to fix incorrect month tags of InfluxDB

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -17,6 +17,16 @@ This is a command line tool to publish your solar production data to [PVoutput.o
 * [Details and Instructions](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/pvoutput/)
 * Script: [pvoutput.py](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/pvoutput/pvoutput.py)
 
+## Fix Month Tags Tool
+
+Prior to Powerwall-Dashboard v2.6.3, "month" tags of InfluxDB data were based on UTC only, resulting in data points with incorrect month tags for the local timezone.
+
+This command line tool can be used to search InfluxDB for incorrect month tags for your timezone and correct the data. A backup is recommended before use.
+
+* Author: [@mcbirse](https://github.com/mcbirse)
+* [Details and Instructions](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/fixmonthtags/)
+* Script: [fixmonthtags.py](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/fixmonthtags/fixmonthtags.py)
+
 ## NodeRed
 
 Several in the community use NodeRed to help automate usage of their Solar and Powerwall data.

--- a/tools/fixmonthtags/README.md
+++ b/tools/fixmonthtags/README.md
@@ -1,0 +1,152 @@
+# Fix Month Tags Tool
+
+This is a command line tool to search InfluxDB for incorrect month tags for your timezone. This tool was submitted by [@mcbirse](https://github.com/mcbirse) and can be used to correct the data problems discovered in issue [#80](https://github.com/jasonacox/Powerwall-Dashboard/issues/80).
+
+## Background
+
+Prior to Powerwall-Dashboard v2.6.3, "month" tags of InfluxDB data were based on UTC only, resulting in data points with incorrect month tags for the local timezone.
+
+The [fixmonthtags.py](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/fixmonthtags/fixmonthtags.py) script can be used to search InfluxDB for incorrect month tags for your timezone and correct the data. A backup is recommended before use.
+
+### Example of incorrect month tags
+
+Below is an example where the local timezone was Australia/Sydney (+10 offset), however due to month tags being in UTC, the "month" tag value remains set to "Aug" up until 10am of the first day in September.
+
+<img alt="image" style="max-width: 100%;" src="https://user-images.githubusercontent.com/108725631/201059160-b47d4981-dce5-4183-b1f3-8c3f646a5675.png">
+
+Incorrect month tags may cause issues in some circumstances, such as:
+* When creating queries where data is GROUPed BY the "month" tag. This will result in values that do not correctly represent the actual month for your timezone.
+* If the [Tesla History Import Tool](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/tesla-history/) was used to fill a data gap which fell within a period where the month tag of existing data was incorrect. This will result in duplicate data points in the kwh retention policy, affecting the analysis data values.
+
+The script can be used to correct these data issues. It could also be used to change timezones or correct the timezone, if for instance the system had been set up with a wrong timezone and changed later.
+
+If you are unsure if your data is affected, it can be safely run to simply check for incorrect month tags - no data corrections will be made without confirmation.
+
+If you have upgraded to Powerwall-Dashboard v2.6.3 or later, the script will only need to be run once to correct the data. All month tags since this version are logged correctly based on your configured timezone.
+
+## Usage
+
+To use the script:
+
+```bash
+# Install required python modules
+pip install python-dateutil influxdb
+
+# Run the script
+python3 fixmonthtags.py
+```
+
+The script will run interactively and prompt you to:
+* configure your InfluxDB database settings and timezone
+* search the database for incorrect month tags
+* correct the data if incorrect month tags are found
+
+### Example usage and output
+
+```
+Fix incorrect month tags of InfluxDB
+------------------------------------
+This script will search InfluxDB for incorrect month tags for your
+configured timezone and correct the data. A backup is recommended.
+
+You will be asked for confirmation before any data corrections are made.
+```
+
+If the config file is not found, you will be prompted to enter your InfluxDB settings.
+
+```
+Config file 'fixmonthtags.conf' not found
+
+Do you want to create the config now? [Y/n]
+
+InfluxDB Setup
+--------------
+Host: [localhost]
+Port: [8086]
+User (leave blank if not used): [blank]
+Pass (leave blank if not used): [blank]
+Database: [powerwall]
+Timezone (e.g. America/Los_Angeles): Australia/Sydney
+
+Config saved to 'fixmonthtags.conf'
+```
+
+This step could be skipped if you have used the Tesla History Import Tool, by using it's saved config.
+
+```bash
+# Run the script using existing config containing your InfluxDB settings
+python3 fixmonthtags.py --config ../tesla-history/tesla-history.conf
+```
+
+To search for incorrect month tags, answer "Y" at the prompt.
+
+The InfluxDB data will then be searched for any incorrect month tags for your timezone.
+
+```
+Do you want to search now? [Y/n]
+
+Searching InfluxDB for incorrect month tags for timezone Australia/Sydney
+* Found incorrect month tags in Jul 2022
+* Found incorrect month tags in Aug 2022
+* Found incorrect month tags in Sep 2022
+```
+
+If any are found and you wish to correct the data, answer "Y" at the prompt.
+
+```
+Do you want to correct the month tags? [y/N] y
+
+This may take some time, please be patient...
+
+Writing corrected data
+Updating analysis data
+Done.
+```
+
+The incorrect month tags will then be corrected, and the analysis data rebuilt.
+
+NOTE: Depending on the number of affected months, this may take some time. _Please be patient and do not abort the script_.
+
+After completion, to confirm the data corrections were successful, you could re-run the script.
+
+```
+Fix incorrect month tags of InfluxDB
+------------------------------------
+This script will search InfluxDB for incorrect month tags for your
+configured timezone and correct the data. A backup is recommended.
+
+You will be asked for confirmation before any data corrections are made.
+
+Do you want to search now? [Y/n]
+
+Searching InfluxDB for incorrect month tags for timezone Australia/Sydney
+* None found
+```
+
+There should be no incorrect month tags reported.
+
+## Additional usage options
+
+```bash
+# Show all usage options
+python3 fixmonthtags.py --help
+```
+
+```
+usage: fixmonthtags.py [-h] [--config CONFIG] [--rebuild]
+
+Fix incorrect month tags of InfluxDB
+
+options:
+  -h, --help       show this help message and exit
+  --config CONFIG  specify an alternate config file (default: fixmonthtags.conf)
+  --rebuild        force rebuild of analysis data
+```
+
+An additional option has been added which may be useful in some circumstances.
+
+* The `--rebuild` option will force a full rebuild of the analysis data
+
+This could be used to rebuild all analysis data retention policies (kwh, daily, and monthly), regardless of whether incorrect month tags exist or not.
+
+It may be useful if for instance invalid analysis data had been identified. This has been seen to occur in rare occasions when the InfluxDB CQ's (continuous queries) that populate the analysis data had failed or taken too long to execute (for example, the host server was overloaded due to high CPU usage). Refer example and comment posts [here](https://github.com/jasonacox/Powerwall-Dashboard/issues/12#issuecomment-1296011292).

--- a/tools/fixmonthtags/fixmonthtags.py
+++ b/tools/fixmonthtags/fixmonthtags.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+ Command line tool to search for incorrect month tags of InfluxDB
+ and correct the data for your configured timezone.
+
+ Author: Michael Birse (for Powerwall-Dashboard by Jason A. Cox)
+ For more information see https://github.com/jasonacox/Powerwall-Dashboard
+
+ Background:
+    Prior to Powerwall-Dashboard v2.6.3, "month" tags of InfluxDB data were
+    based on UTC only, resulting in data points with incorrect month tags for
+    the local timezone.
+
+    This script will search InfluxDB for incorrect month tags for your
+    configured timezone and correct the data. A backup is recommended.
+
+ Usage:
+    * Install the required python modules:
+        pip install python-dateutil influxdb
+
+    * Run this script:
+        python3 fixmonthtags.py
+
+    The script will run interactively and prompt you to:
+        - configure your InfluxDB database settings and timezone
+        - search the database for incorrect month tags
+        - correct the data if incorrect month tags are found
+
+    * For additional usage options:
+        python3 fixmonthtags.py --help
+"""
+import sys
+import os
+import argparse
+import configparser
+try:
+    from dateutil.relativedelta import relativedelta
+    from dateutil.parser import isoparse
+    from dateutil import tz
+except:
+    sys.exit("ERROR: Missing python dateutil module. Run 'pip install python-dateutil'.")
+try:
+    from influxdb import InfluxDBClient
+except:
+    sys.exit("ERROR: Missing python influxdb module. Run 'pip install influxdb'.")
+
+SCRIPTPATH = os.path.dirname(os.path.realpath(sys.argv[0]))
+SCRIPTNAME = os.path.basename(sys.argv[0]).split('.')[0]
+CONFIGNAME = CONFIGFILE = f"{SCRIPTNAME}.conf"
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description='Fix incorrect month tags of InfluxDB')
+parser.add_argument('--config', help=f'specify an alternate config file (default: {CONFIGNAME})')
+parser.add_argument('--rebuild', action="store_true", help='force rebuild of analysis data')
+args = parser.parse_args()
+
+print("Fix incorrect month tags of InfluxDB")
+print("------------------------------------")
+print("This script will search InfluxDB for incorrect month tags for your")
+print("configured timezone and correct the data. A backup is recommended.\n")
+print("You will be asked for confirmation before any data corrections are made.\n")
+
+if args.config:
+    # Use alternate config file if specified
+    CONFIGNAME = CONFIGFILE = args.config
+
+# Load Configuration File
+config = configparser.ConfigParser(allow_no_value=True)
+if not os.path.exists(CONFIGFILE) and "/" not in CONFIGFILE:
+    # Look for config file in script location if not found
+    CONFIGFILE = f"{SCRIPTPATH}/{CONFIGFILE}"
+if os.path.exists(CONFIGFILE):
+    try:
+        config.read(CONFIGFILE)
+
+        # Get InfluxDB Settings
+        IHOST = config.get('InfluxDB', 'HOST')
+        IPORT = config.get('InfluxDB', 'PORT')
+        IUSER = config.get('InfluxDB', 'USER', fallback='')
+        IPASS = config.get('InfluxDB', 'PASS', fallback='')
+        IDB = config.get('InfluxDB', 'DB')
+        ITZ = config.get('InfluxDB', 'TZ')
+    except Exception as err:
+        sys.exit(f"ERROR: Config file '{CONFIGNAME}' - {err}")
+else:
+    # Config not found - prompt user for configuration and save settings
+    print(f"Config file '{CONFIGNAME}' not found\n")
+
+    while True:
+        response = input("Do you want to create the config now? [Y/n] ")
+        if response.lower() == "n":
+            sys.exit()
+        elif response.lower() in ("y", ""):
+            break
+
+    print("\nInfluxDB Setup")
+    print("-" * 14)
+
+    while True:
+        response = input("Host: [localhost] ")
+        if response.strip() == "":
+            IHOST = "localhost"
+        else:
+            IHOST = response.strip()
+        break
+
+    while True:
+        response = input("Port: [8086] ")
+        if response.strip() == "":
+            IPORT = "8086"
+        else:
+            IPORT = response.strip()
+        break
+
+    response = input("User (leave blank if not used): [blank] ")
+    IUSER = response.strip()
+
+    response = input("Pass (leave blank if not used): [blank] ")
+    IPASS = response.strip()
+
+    while True:
+        response = input("Database: [powerwall] ")
+        if response.strip() == "":
+            IDB = "powerwall"
+        else:
+            IDB = response.strip()
+        break
+
+    while True:
+        response = input("Timezone (e.g. America/Los_Angeles): ")
+        if response.strip() != "":
+            ITZ = response.strip()
+            if tz.gettz(ITZ) is None:
+                print("Invalid timezone\n")
+                continue
+            break
+
+    # Set config values
+    config.optionxform = str
+    config['InfluxDB'] = {}
+    config['InfluxDB']['HOST'] = IHOST
+    config['InfluxDB']['PORT'] = IPORT
+    config['InfluxDB']['USER'] = IUSER
+    config['InfluxDB']['PASS'] = IPASS
+    config['InfluxDB']['DB'] = IDB
+    config['InfluxDB']['TZ'] = ITZ
+
+    try:
+        # Write config file
+        with open(CONFIGFILE, 'w') as configfile:
+            config.write(configfile)
+    except Exception as err:
+        print(f"\nERROR: Failed to save config to '{CONFIGNAME}' - {err}\n")
+    else:
+        print(f"\nConfig saved to '{CONFIGNAME}'\n")
+
+# Global Variables
+start = end = None
+datapoints = {}
+rplist = []
+taglist = []
+months = []
+
+def search_influx(remove=False):
+    """
+    Search InfluxDB for incorrect month tags for the configured timezone
+        * Adds corrected data points for each retention policy to 'datapoints'
+
+    Args:
+        remove  = If True, removes previously found data points with incorrect month tags
+    """
+    global start, end
+
+    if start is None:
+        try:
+            # Find first and last data points
+            query = "SELECT * FROM http LIMIT 1"
+            firstpoint = client.query(query)
+            query = "SELECT * FROM http ORDER BY time DESC LIMIT 1"
+            lastpoint = client.query(query)
+        except Exception as err:
+            sys.exit(f"ERROR: Failed to execute InfluxDB query: {query}; {err}")
+
+        try:
+            start = isoparse(list(firstpoint.get_points())[0]['time']).astimezone(influxtz)
+            end = isoparse(list(lastpoint.get_points())[0]['time']).astimezone(influxtz)
+        except Exception:
+            sys.exit("ERROR: No data points found")
+
+    if not rplist:
+        try:
+            # Get list of retention policies
+            query = "SHOW RETENTION POLICIES"
+            result = client.query(query)
+            for rp in result.get_points():
+                rplist.append(rp['name'])
+        except Exception as err:
+            sys.exit(f"ERROR: Failed to execute InfluxDB query: {query}; {err}")
+
+    if not taglist:
+        try:
+            # Get list of tag keys
+            query = "SHOW TAG KEYS FROM http"
+            result = client.query(query)
+            for tag in result.get_points():
+                taglist.append(tag['tagKey'])
+        except Exception as err:
+            sys.exit(f"ERROR: Failed to execute InfluxDB query: {query}; {err}")
+
+    startmonth = start.replace(day=1, hour=0, minute=0, second=0)
+    endmonth = end + relativedelta(months=1, day=1, hour=0, minute=0, second=0)
+
+    # Loop through each month to search tags by month
+    month = startmonth
+    while month < endmonth:
+        nextmonth = month + relativedelta(months=1, day=1, hour=0, minute=0, second=0)
+
+        if remove and month not in months:
+            # Increment to next month if there were no wrong tags found within current month
+            month += relativedelta(months=1, day=1, hour=0, minute=0, second=0)
+            continue
+
+        for rp in rplist:
+            if rp in ('kwh', 'daily', 'monthly'):
+                continue
+            try:
+                if not remove:
+                    # Find points within current month where month tag does not match localized month
+                    query = f"SELECT * FROM {rp}.http WHERE month != '{month.strftime('%b')}' AND time >= '{month.isoformat()}' AND time < '{nextmonth.isoformat()}'"
+                    result = client.query(query)
+                else:
+                    # Remove points within current month for all retention policies where month tag does not match localized month
+                    query = f"DELETE FROM http WHERE month != '{month.strftime('%b')}' AND time >= '{month.isoformat()}' AND time < '{nextmonth.isoformat()}'"
+                    client.query(query)
+                    break
+            except Exception as err:
+                sys.exit(f"ERROR: Failed to execute InfluxDB query: {query}; {err}")
+
+            pts = len(list(result.get_points()))
+            if pts > 0:
+                if month not in months:
+                    # Save month where incorrect tags found
+                    print(f"* Found incorrect month tags in {month.strftime('%b %Y')}")
+                    months.append(month)
+
+                for point in result.get_points():
+                    timestamp = isoparse(point['time']).astimezone(influxtz)
+                    tags = ""
+                    data = ""
+                    for key, value in point.items():
+                        if key == 'time' or value is None:
+                            continue
+                        if key in taglist:
+                            if key == 'month':
+                                # Set month tag to correct value for the timezone
+                                value = timestamp.strftime('%b')
+                            if key == 'year':
+                                # Set year tag to correct value for the timezone
+                                value = timestamp.year
+                            # Save tag values
+                            tags += f",{key}={value}"
+                        else:
+                            # Save data values
+                            data += f",{key}={value}"
+
+                    # Save the corrected data point values
+                    newpoint = f"http{tags} {data[1:]} {str(int(timestamp.timestamp()))}"
+                    if rp not in datapoints:
+                        datapoints[rp] = []
+                    datapoints[rp].append(newpoint)
+
+        # Increment to next month
+        month += relativedelta(months=1, day=1, hour=0, minute=0, second=0)
+
+def write_influx():
+    """
+    Replace incorrect data points with the corrected data for each retention policy
+    """
+    print("Writing corrected data")
+    try:
+        # Write corrected data points
+        for rp, points in datapoints.items():
+            client.write_points(points, time_precision='s', batch_size=10000, retention_policy=rp, protocol='line')
+    except Exception as err:
+        sys.exit(f"ERROR: Failed to write to InfluxDB: {err}")
+
+    # Remove incorrect data points
+    search_influx(remove=True)
+
+def update_influx():
+    """
+    Update analysis data retention policies (kwh, daily, monthly)
+        * Full rebuild required due to potential non-hourly timezone offsets
+    """
+    print("Updating analysis data")
+    try:
+        # Drop/create retention policies to clear previous data
+        query = f"DROP RETENTION POLICY kwh ON {IDB}"
+        client.query(query)
+        query = f"DROP RETENTION POLICY daily ON {IDB}"
+        client.query(query)
+        query = f"DROP RETENTION POLICY monthly ON {IDB}"
+        client.query(query)
+        query = f"CREATE RETENTION POLICY kwh ON {IDB} duration INF replication 1"
+        client.query(query)
+        query = f"CREATE RETENTION POLICY daily ON {IDB} duration INF replication 1"
+        client.query(query)
+        query = f"CREATE RETENTION POLICY monthly ON {IDB} duration INF replication 1"
+        client.query(query)
+
+        # Update hourly analysis data
+        query = "SELECT integral(home)/1000/3600 AS home, integral(solar)/1000/3600 AS solar, integral(from_pw)/1000/3600 AS from_pw, integral(to_pw)/1000/3600 AS to_pw, integral(from_grid)/1000/3600 AS from_grid, integral(to_grid)/1000/3600 AS to_grid "
+        query += "INTO kwh.:MEASUREMENT FROM autogen.http "
+        query += f"GROUP BY time(1h), month, year tz('{ITZ}')"
+        client.query(query)
+
+        # Update daily analysis data
+        query = "SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid "
+        query += "INTO daily.:MEASUREMENT FROM kwh.http "
+        query += f"GROUP BY time(1d), month, year tz('{ITZ}')"
+        client.query(query)
+
+        # Update monthly analysis data
+        query = "SELECT sum(home) AS home, sum(solar) AS solar, sum(from_pw) AS from_pw, sum(to_pw) AS to_pw, sum(from_grid) AS from_grid, sum(to_grid) AS to_grid "
+        query += "INTO monthly.:MEASUREMENT FROM daily.http "
+        query += "GROUP BY time(365d), month, year"
+        client.query(query)
+    except Exception as err:
+        sys.exit(f"ERROR: Failed to execute InfluxDB query: {query}; {err}")
+
+# MAIN
+
+# Check InfluxDB timezone is valid
+influxtz = tz.gettz(ITZ)
+if influxtz is None:
+    sys.exit(f"ERROR: Invalid timezone - {ITZ}")
+
+try:
+    # Connect to InfluxDB
+    client = InfluxDBClient(host=IHOST, port=IPORT, username=IUSER, password=IPASS, database=IDB)
+except Exception as err:
+    sys.exit(f"ERROR: Failed to connect to InfluxDB: {err}")
+
+while True:
+    # Prompt to search for incorrect month tags
+    response = input("Do you want to search now? [Y/n] ")
+    if response.lower() == "n":
+        sys.exit()
+    elif response.lower() in ("y", ""):
+        print()
+        break
+
+# Search for incorrect month tags
+print(f"Searching InfluxDB for incorrect month tags for timezone {ITZ}")
+search_influx()
+
+if not datapoints:
+    # Exit if no wrong tags were found
+    print("* None found\n")
+    if args.rebuild:
+        # Update analysis data if rebuild option was given
+        update_influx()
+        print("Done.")
+    sys.exit()
+
+while True:
+    # Prompt to correct the month tags
+    response = input("\nDo you want to correct the month tags? [y/N] ")
+    if response.lower() in ("n", ""):
+        if args.rebuild:
+            # Update analysis data if rebuild option was given
+            print()
+            update_influx()
+            print("Done.")
+        sys.exit()
+    elif response.lower() == "y":
+        print("\nThis may take some time, please be patient...\n")
+        break
+
+# Write corrected data
+write_influx()
+# Update analysis data
+update_influx()
+print("Done.")


### PR DESCRIPTION
Hi @jasonacox 

Adding this script to the tools repository which hopefully should be useful for those affected by issue #80 and wanting to correct the data.

This python script can be used to fix incorrect month tags of InfluxDB where the month was based on UTC instead of the local timezone. My data is fixed now. 😊