### PR TITLE
Change frequency panel to 3 decimal places

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -6116,7 +6116,7 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "decimals": 1,
+      "decimals": 3,
       "description": "",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
The frequency panel is a bit hard to understand because frequency is commonly fluctuating only between a very small range. 

The hover tooltip becomes a bit useless at one decimal place because it rounds the number and it's not possible to distinguish when the value changes.

<img width="2933" alt="image" src="https://user-images.githubusercontent.com/484912/214776132-d721ba4c-5a8e-422f-bd85-b2066e120dbb.png">

Changing to 3 decimal places allows you to see the actual fluctutation clearer.

<img width="2923" alt="image" src="https://user-images.githubusercontent.com/484912/214776246-3d2781b3-9d3a-4e57-8a80-9ae6b33797ab.png">
