### PR TITLE
Change voltage graph to dual axis

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -6701,63 +6701,99 @@
       }
     },
     {
-      "aliasColors": {
-        "Solar Energy": "yellow"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "decimals": 1,
       "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
           "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "volt"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "PW[\\d+] L[\\d+]"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
-      "fill": 0,
-      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 24,
         "x": 0,
         "y": 63
       },
-      "hiddenSeries": false,
       "id": 61,
       "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
-        "max": true,
-        "min": true,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "connected",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
       "pluginVersion": "9.1.2",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "alias": "Home L1",
@@ -7515,38 +7551,9 @@
           "tags": []
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Voltages",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1953",
-          "format": "volt",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1954",
-          "format": "short",
-          "logBase": 1,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     },
     {
       "aliasColors": {},


### PR DESCRIPTION
In countries with [230V electric grids](https://en.wikipedia.org/wiki/Mains_electricity_by_country) (e.g. Australia), the voltage graph is a bit odd because the grid voltages and Powerwall voltages are entirely separated, because the Powerwall always operates at 120V. I imagine this is not a problem in 120V electric grids (e.g. USA).

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/484912/215056638-d738a16e-9091-4930-8774-097f9801aa40.png">

This makes it pretty hard to see the changes in voltage because the axis is quite large.

Initially I thought about splitting this graph into two, one for the grid voltages and another for the Powerwall voltages, but then I remembered one graph can have two axis. 

So I put all the Powerwall voltages on the right axis (using a field name regex), which actually works out pretty well because they're always in-sync with the grid voltages anway, just halved.

<img width="1481" alt="image" src="https://user-images.githubusercontent.com/484912/215056904-3d3f1801-0998-4085-b037-13c0d6ee538f.png">

I had to change the visualization from "Graph (Old)" to "Time series" because the legacy graph did not allow for overriding the axis placement by field. I used the migration button which seems to have worked. I wonder if all the other graphs should also be updated?

<img width="367" alt="image" src="https://user-images.githubusercontent.com/484912/215056283-abcc0c97-3177-48cc-bd12-f415718706ce.png">
