### PR TITLE
Grid Voltage Upgrade - fix run-once script so tags are also copied with historic data

### DIFF
--- a/influxdb/run-once-2.8.0.sql
+++ b/influxdb/run-once-2.8.0.sql
@@ -10,6 +10,6 @@
 # USE powerwall
 CREATE DATABASE powerwall
 # Use METER data from vitals as ISLAND data to fill history
-SELECT METER_X_VL1N AS ISLAND_VL1N_Main, METER_X_VL2N AS ISLAND_VL2N_Main, METER_X_VL3N AS ISLAND_VL3N_Main INTO powerwall.vitals.:MEASUREMENT FROM (SELECT METER_X_VL1N, METER_X_VL2N, METER_X_VL3N FROM powerwall.vitals.http)
+SELECT METER_X_VL1N AS ISLAND_VL1N_Main, METER_X_VL2N AS ISLAND_VL2N_Main, METER_X_VL3N AS ISLAND_VL3N_Main INTO powerwall.vitals.:MEASUREMENT FROM (SELECT METER_X_VL1N, METER_X_VL2N, METER_X_VL3N FROM powerwall.vitals.http GROUP BY month, year) GROUP BY month, year
 # User current ISLAND from raw data - same as cq_vitals7
 SELECT mean(ISLAND_VL1N_Main) AS ISLAND_VL1N_Main, mean(ISLAND_VL2N_Main) AS ISLAND_VL2N_Main, mean(ISLAND_VL3N_Main) AS ISLAND_VL3N_Main INTO powerwall.vitals.:MEASUREMENT FROM (SELECT ISLAND_VL1N_Main, ISLAND_VL2N_Main, ISLAND_VL3N_Main FROM powerwall.raw.http) GROUP BY time(15s), month, year fill(linear)


### PR DESCRIPTION
There is an issue with the run-once script that copies the `METER_X_VLxN` data into `ISLAND_VLxN_Main` (sorry I did not notice this earlier... been busy last few weeks and only now attempted the upgrade!).

The first `SELECT INTO` query which copies historical data from `METER_X_VLxN` into `ISLAND_VLxN_Main` does not include the "tags" (i.e. the month & year tags).

If tags are not copied, the historical data added into `ISLAND_VLxN_Main` will not be tagged with the month & year - which is inconsistent with how existing data is stored and how all the CQ's are currently defined. This could create some potential issues, especially if grouping data by the month tag, for example.

This issue can been seen below in the green plot line, which shows the historical data added into `ISLAND_VLxN_Main` wasn't tagged with the month & year, as per the original data being copied from `METER_X_VLxN`.

![image](https://user-images.githubusercontent.com/108725631/218077831-d2018f0d-c326-4b4a-ac79-9b6f3cef7371.png)

Another issue occurs from the second query, which is duplicate data points are created for the data resampled from raw (last 3 days) into `ISLAND_VLxN_Main`, since this query includes the tags, but the data copied from `METER_X_VLxN` does not (refer [InfluxDB duplicate data points](https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/#how-does-influxdb-handle-duplicate-points) - to update data, the same timestamp and _tag set_ must be used, otherwise duplicate points are created).

![image](https://user-images.githubusercontent.com/108725631/218079243-f7f6badd-603e-4c1e-81dd-ec764b0bfc60.png)

This PR updates the script to add `GROUP BY month, year` clauses for the historical data copy from `METER_X_VLxN` which ensures the tags are included.

The example below shows the result after running the updated script - tags are copied correctly for the historical data into `ISLAND_VLxN_Main`.

![image](https://user-images.githubusercontent.com/108725631/218080268-ccfb8621-60d0-48f6-a427-ba3421adfc4e.png)

The resampled raw data will also update `ISLAND_VLxN_Main` without creating duplicate data points.

![image](https://user-images.githubusercontent.com/108725631/218080721-81acd87c-d696-4c41-9ef2-218b5eef820c.png)

Please note, if the script had been run before (i.e. during the upgrade process), DO NOT re-run it to correct the data. This would simply create more duplicate data points instead! 😞

However, for anyone that already upgraded to 2.8.0 or later, there is an option to fix the untagged data for anyone that wants to... running the [Fix Month Tags Tool](https://github.com/jasonacox/Powerwall-Dashboard/blob/main/tools/fixmonthtags/) will fix these issues. You're welcome. 🙇 😊 