### PR TITLE
Support customised powerwall.yml through upgrade.

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -72,6 +72,17 @@ else
     exit 
 fi
 
+# Preserve Customised powerwall.yml?
+read -r -p "Do you want to preserve a customised powerwall.yml (only for specialised users)? [y/N] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+then
+    echo "preseving powerwall.yml"
+    cp "powerwall.yml" "powerwall.yml.restore"
+else
+    echo "Replacing powerwall.yml with standard as part of upgrade"
+fi
+
+
 # Remember Timezome and Reset to Default
 echo "Resetting Timezone to Default..."
 DEFAULT="America/Los_Angeles"
@@ -139,6 +150,12 @@ if ! grep -q "TZ=" pypowerwall.env; then
     echo "Adding..."
     echo "TZ=America/Los_Angeles" >> pypowerwall.env
 fi
+
+if [ -f powerwall.yml.preserve ]; then
+    echo "restoring preserved powerwall.yml"
+    cp "powerwall.yml.restore" "powerwall.yml"
+fi
+
 
 # Make sure stack is running
 echo ""

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -63,6 +63,15 @@ if [ ! -f ${ENV_FILE} ]; then
 fi
 
 # Verify Upgrade
+echo "If you have customised your powerwall.yml file, you can preseve it through the upgrade"
+echo "This feature is only for advanced users who know what they are doing and have reviewed"
+echo "any changes in the powerwall.yml file before starting this upgrade."
+echo "If you thing you might want to do this, but have not reviewed your file, cancel the"
+echo "upgrade at the next step, and review your powerwall.yml file for any changes first."
+echo ""
+echo "This feature can be ignore by most users."
+echo ""
+echo ""
 read -r -p "Upgrade - Proceed? [y/N] " response
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
 then
@@ -73,11 +82,11 @@ else
 fi
 
 # Preserve Customised powerwall.yml?
-read -r -p "Do you want to preserve a customised powerwall.yml (only for specialised users)? [y/N] " response
+read -r -p "Do you want to preserve your customised powerwall.yml? [y/N] " response
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-    echo "preseving powerwall.yml"
-    cp "powerwall.yml" "powerwall.yml.restore"
+    echo "Copy powerwall.yml to powerwall.yml.preserve"
+    cp "powerwall.yml" "powerwall.yml.preserve"
 else
     echo "Replacing powerwall.yml with standard as part of upgrade"
 fi
@@ -152,8 +161,8 @@ if ! grep -q "TZ=" pypowerwall.env; then
 fi
 
 if [ -f powerwall.yml.preserve ]; then
-    echo "restoring preserved powerwall.yml"
-    cp "powerwall.yml.restore" "powerwall.yml"
+    echo "Restoring preserved powerwall.yml"
+    cp "powerwall.yml.preserve" "powerwall.yml"
 fi
 
 


### PR DESCRIPTION
Supports a customised powerwall.yml Docker Compose file through the upgrade by preserving it before the upgrade by copying it to a .restore copy, and restoring it after the git pull before restarting the containers.

Note that I haven't actually been able to test this, given that the upgrade.sh script runs itself from the latest version from your repo; I'm pretty confident, though; what I'm going to do is create this pull request, then edit my script again so that it pulls from my fork (and thus gets my new script) to test that it works - I'll comment back here again to confirm it works.