### PR TITLE
Weather411 - Upgrade InfluxDB Client - v0.2.0

### DIFF
--- a/weather/Dockerfile
+++ b/weather/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 WORKDIR /app
-RUN pip3 install influxdb
+RUN pip3 install influxdb-client
 COPY server.py server.py
 COPY README.md README.md
 CMD ["python3", "server.py"]

--- a/weather/Dockerfile
+++ b/weather/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 WORKDIR /app
-RUN pip3 install influxdb-client
+RUN pip3 install requests influxdb-client
 COPY server.py server.py
 COPY README.md README.md
 CMD ["python3", "server.py"]

--- a/weather/README.md
+++ b/weather/README.md
@@ -16,7 +16,6 @@ Docker: docker pull [jasonacox/weather411](https://hub.docker.com/r/jasonacox/we
 
 ## Quick Start
 
-
 1. Create a `weather411.conf` file (`cp weather411.conf.sample weather411.conf`) and update with your specific location details:
 
     * Enter your OpenWeatherMap API Key (APIKEY) You can get a free account and key at [OpenWeatherMap.org](https://openweathermap.org/). 
@@ -52,6 +51,13 @@ Docker: docker pull [jasonacox/weather411](https://hub.docker.com/r/jasonacox/we
     # Leave blank if not used
     USERNAME = 
     PASSWORD =
+    # Auth - Leave blank if not used
+    USERNAME =
+    PASSWORD =
+    # Influx 2.x - Leave blank if not used
+    TOKEN =
+    ORG =
+    URL =
     ```
 
 2. Run the Docker Container to listen on port 8676.
@@ -143,7 +149,7 @@ docker start weather411
 
 ### 0.2.0 - Upgrade InfluxDB Client
 
-* Upgrade end of life `influxdb` client library to `influxdb-client` (refer discussion #191 and issue #195)
+* Upgrade end of life `influxdb` client library to `influxdb-client` (refer discussion #191 and issue #195), providing support for InfluxDB 1.8 and 2.x.
 
 ### 0.1.2 - Snow and Rain Data
 

--- a/weather/README.md
+++ b/weather/README.md
@@ -141,6 +141,10 @@ docker start weather411
 
 ## Release Notes
 
+### 0.2.0 - Upgrade InfluxDB Client
+
+* Upgrade end of life `influxdb` client library to `influxdb-client` (refer discussion #191 and issue #195)
+
 ### 0.1.2 - Snow and Rain Data
 
 * Fix rain and snow values not being retrieved (refer issue #42) by @mcbirse (PR #69)

--- a/weather/README.md
+++ b/weather/README.md
@@ -48,9 +48,6 @@ Docker: docker pull [jasonacox/weather411](https://hub.docker.com/r/jasonacox/we
     PORT = 8086
     DB = powerwall
     FIELD = weather
-    # Leave blank if not used
-    USERNAME = 
-    PASSWORD =
     # Auth - Leave blank if not used
     USERNAME =
     PASSWORD =

--- a/weather/server.py
+++ b/weather/server.py
@@ -277,10 +277,8 @@ def fetchWeather():
                                 output[0]["fields"][i] = weather[i]
                             # print(output)
                             write_api = client.write_api(write_options=SYNCHRONOUS)
-                            if write_api.write(IDB,IORG,output):
-                                serverstats['influxdb'] += 1
-                            else:
-                                serverstats['influxdberrors'] += 1
+                            write_api.write(IDB,IORG,output)
+                            serverstats['influxdb'] += 1
                             client.close()
                         except:
                             log.debug("Error writing to InfluxDB")

--- a/weather/server.py
+++ b/weather/server.py
@@ -43,6 +43,13 @@
         PORT = 8086
         DB = powerwall
         FIELD = weather
+        # Auth - Leave blank if not used
+        USERNAME =
+        PASSWORD =
+        # Auth - Influx 2.x - Leave blank if not used
+        TOKEN =
+        ORG =
+        URL =
 
     ENVIRONMENTAL:
         WEATHERCONF = "Path to weather411.conf file"
@@ -114,7 +121,10 @@ if os.path.exists(CONFIGFILE):
     # Check for InfluxDB 2.x settings
     ITOKEN = config.get('InfluxDB', 'TOKEN', fallback="") 
     IORG = config.get('InfluxDB', 'ORG', fallback="") 
+    IURL = config.get('InfluxDB', 'URL', fallback="") 
 
+    if ITOKEN != "" and IURL == "":
+        IURL = "http://%s:%s" % (IHOST, IPORT)
 else:
     # No config file - Display Error
     sys.stderr.write("Weather411 Server %s\nERROR: No config file. Fix and restart.\n" % BUILD)
@@ -266,7 +276,7 @@ def fetchWeather():
                             else :
                                 # Influx 2.x
                                 client = InfluxDBClient(
-                                    url="http://%s:%s" % (IHOST,IPORT),
+                                    url=IURL,
                                     token=ITOKEN,
                                     org=IORG)
                             output = [{}]
@@ -430,8 +440,8 @@ if __name__ == "__main__":
     sys.stderr.write(" + InfluxDB - Enable: %s, Host: %s, Port: %s, DB: %s, Field: %s\n"
         % (INFLUX, IHOST, IPORT, IDB, IFIELD))
     if ITOKEN != "" or IORG != "":
-        sys.stderr.write(" + InfluxDB - Org: %s, Token: %s\n"
-            % (IORG, ITOKEN))
+        sys.stderr.write(" + InfluxDB - URL: %s, Org: %s, Token: %s\n"
+            % (IURL, IORG, ITOKEN))
     
     # Start threads
     sys.stderr.write("* Starting threads\n")

--- a/weather/server.py
+++ b/weather/server.py
@@ -75,7 +75,7 @@ import os
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from socketserver import ThreadingMixIn 
 import configparser
-from influxdb_client import WritePrecision, InfluxDBClient, Point
+from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
 
 BUILD = "0.2.0"
@@ -431,6 +431,9 @@ if __name__ == "__main__":
         % (OWKEY, OWWAIT, OWUNITS, OWLAT, OWLON, TIMEOUT))
     sys.stderr.write(" + InfluxDB - Enable: %s, Host: %s, Port: %s, DB: %s, Field: %s\n"
         % (INFLUX, IHOST, IPORT, IDB, IFIELD))
+    if ITOKEN != "" or IORG != "":
+        sys.stderr.write(" + InfluxDB - Org: %s, Token: %s\n"
+            % (IORG, ITOKEN))
     
     # Start threads
     sys.stderr.write("* Starting threads\n")

--- a/weather/server.py
+++ b/weather/server.py
@@ -69,7 +69,7 @@ import logging
 import json
 import requests
 import resource
-import datetime
+from datetime import datetime
 import sys
 import os
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
@@ -109,10 +109,11 @@ if os.path.exists(CONFIGFILE):
     IPORT = int(config["InfluxDB"]["PORT"])
     IUSER = config["InfluxDB"]["USERNAME"]
     IPASS = config["InfluxDB"]["PASSWORD"]
-    ITOKEN = config["InfluxDB"]["TOKEN"]
-    IORG = config["InfluxDB"]["ORG"]
     IDB = config["InfluxDB"]["DB"]
     IFIELD = config["InfluxDB"]["FIELD"]
+    # Check for InfluxDB 2.x settings
+    ITOKEN = config.get('InfluxDB', 'TOKEN', fallback="") 
+    IORG = config.get('InfluxDB', 'ORG', fallback="") 
 
 else:
     # No config file - Display Error
@@ -337,9 +338,9 @@ class handler(BaseHTTPRequestHandler):
                     message = message + '<tr><td align ="right">%s</td><td align ="right">%s</td></tr>\n' % (i, weather[i])
                 message = message + "</table>\n"
             message = message + '<p>Last data update: %s<br><font size=-2>From URL: %s</font></p>' % (
-                str(datetime.datetime.fromtimestamp(weather['dt'])), URL)
+                str(datetime.fromtimestamp(weather['dt'])), URL)
             message = message + '\n<p>Page refresh: %s</p>\n</body>\n</html>' % (
-                str(datetime.datetime.fromtimestamp(time.time())))
+                str(datetime.fromtimestamp(time.time())))
         elif self.path == '/stats':
             # Give Internal Stats
             serverstats['ts'] = int(time.time())
@@ -351,9 +352,9 @@ class handler(BaseHTTPRequestHandler):
             message = json.dumps(raw)
         elif self.path == '/time':
             ts = time.time()
-            result["local_time"] = str(datetime.datetime.fromtimestamp(ts))
+            result["local_time"] = str(datetime.fromtimestamp(ts))
             result["ts"] = ts
-            result["utc"] = str(datetime.datetime.utcfromtimestamp(ts)) 
+            result["utc"] = str(datetime.utcfromtimestamp(ts)) 
             result["tz"] = weather["tz"]
             message = json.dumps(result)
         elif self.path == '/temp':

--- a/weather/weather411.conf.sample
+++ b/weather/weather411.conf.sample
@@ -24,7 +24,10 @@ HOST = influxdb
 PORT = 8086
 DB = powerwall
 FIELD = weather
-# Leave blank if not used
-USERNAME = 
+# Auth - Leave blank if not used
+USERNAME =
 PASSWORD =
+# Auth - Influx 2.x - Leave blank if not used
+TOKEN =
+ORG =
 

--- a/weather/weather411.conf.sample
+++ b/weather/weather411.conf.sample
@@ -27,7 +27,8 @@ FIELD = weather
 # Auth - Leave blank if not used
 USERNAME =
 PASSWORD =
-# Auth - Influx 2.x - Leave blank if not used
+# Influx 2.x - Leave blank if not used
 TOKEN =
 ORG =
+URL =
 


### PR DESCRIPTION
The influxdb library used by weather411 is end of life and supports only InfluxDB 1.x.  This PR will upgrade weather411 to use the latest influxdb-client library which supports both Influxdb 1.8 and 2.x versions.

To use this with InfluxDB 2.x, the user will need to edit the weather411.conf file and include the API `TOKEN` and `ORG` values.

```
        # Auth - Influx 2.x - Leave blank if not used
        TOKEN =
        ORG =
        URL =
```

This closes #195 