### PR TITLE
Add code to power flow animation dashboard panel to auto-scale based on window size

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -1039,7 +1039,7 @@
       "id": 13,
       "links": [],
       "options": {
-        "content": "<div style=\"text-align: center\">\n<iframe id=\"frame\" src=\"/public/img/grafana_icon.svg\" width=\"100%\" height=\"290\" frameBorder=\"0\">No</iframe>\n<p class=\"version\" style=\"color:gray;\">Firmware</p>\n<script>\n// Get Firmware Version\nfunction showversion() {\n    var pwver = window.location.protocol + \"//\" + window.location.hostname + \":8675/version\";\n    $.getJSON(pwver, function(data) {\n        var text = `Firmware: ${data.version.split(\" \")[0]}`;\n        $(\".version\").html(text);\n    });\n    setTimeout(showversion, 60000);\n}\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\ndocument.getElementById('frame').src = pwurl;\nshowversion();\n</script>\n</div>",
+        "content": "<style>\n.powerDiv {\n      width: 100%;\n      height: 100%;\n      position: absolute;\n      left: 50%;\n      top: 50%;\n    }\n.firmwareDiv {\n      width: 100%;\n      position: absolute;\n      text-align: center;\n      left: 0%;\n      bottom: 0%;\n    }\n.powerFrame {\n      width: 500px;\n      height: 300px;\n      transform: scale(0);\n      transform-origin: 0 0;\n      position: absolute;\n      left: 0;\n      top: 0;\n      border-style: none;\n    }\n</style>\n<div class=\"powerDiv\">\n    <iframe id=\"frame8675\" class=\"powerFrame\" src=\"/public/img/grafana_icon.svg\" onload=\"scale(this)\">IFRAME not supported by browser.</iframe>\n    <script>\n    document.getElementById('frame8675').parentElement.parentElement.parentElement.style.overflow = 'hidden';\n    </script>\n</div>\n<div class=\"firmwareDiv\">\n  <p class=\"version\" style=\"color:gray; text-align: bottom\">Firmware</p>\n</div>\n<script>\n// Scale Animation when Window is Resized\nfunction scale() {\n  document.querySelectorAll('.powerFrame').forEach(scaled => {\n    parent = scaled.parentNode;\n    ratio = 1.2 * Math.min((parent.offsetWidth / scaled.offsetWidth), (parent.offsetHeight / scaled.offsetHeight));\n    if (ratio > 1.0) ratio = 1.0;\n    scaled.style.transform = 'scale(' + ratio + ')  translate(-50%, -50%)';\n    scaled.style.transformOrigin = 'top left';\n  })\n}\nwindow.addEventListener('resize', function(e){ scale(); }, false);\n\n// Display Firmware Version\nfunction showversion() {\n    var pwver = window.location.protocol + \"//\" + window.location.hostname + \":8675/version\";\n    $.getJSON(pwver, function(data) {\n        var text = `Firmware: ${data.version.split(\" \")[0]}`;\n        $(\".version\").html(text);\n    });\n    setTimeout(showversion, 60000);\n}\nshowversion();\n\n// Load Animation from pyPowerwall\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\ndocument.getElementById('frame8675').src = pwurl;\n\n</script>",
         "mode": "html"
       },
       "pluginVersion": "9.1.2",
@@ -9648,6 +9648,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzV",
-  "version": 31,
+  "version": 39,
   "weekStart": ""
 }

--- a/dashboards/dashboard.json
+++ b/dashboards/dashboard.json
@@ -1039,7 +1039,7 @@
       "id": 13,
       "links": [],
       "options": {
-        "content": "<div style=\"text-align: center\">\n<iframe id=\"frame\" src=\"/public/img/grafana_icon.svg\" width=\"100%\" height=\"290\" frameBorder=\"0\">No</iframe>\n<p class=\"version\" style=\"color:gray;\">Firmware</p>\n<script>\n// Get Firmware Version\nfunction showversion() {\n    var pwver = window.location.protocol + \"//\" + window.location.hostname + \":8675/version\";\n    $.getJSON(pwver, function(data) {\n        var text = `Firmware: ${data.version.split(\" \")[0]}`;\n        $(\".version\").html(text);\n    });\n    setTimeout(showversion, 60000);\n}\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\ndocument.getElementById('frame').src = pwurl;\nshowversion();\n</script>\n</div>",
+        "content": "<style>\n.powerDiv {\n      width: 100%;\n      height: 100%;\n      position: absolute;\n      left: 50%;\n      top: 50%;\n    }\n.firmwareDiv {\n      width: 100%;\n      position: absolute;\n      text-align: center;\n      left: 0%;\n      bottom: 0%;\n    }\n.powerFrame {\n      width: 500px;\n      height: 300px;\n      transform: scale(0);\n      transform-origin: 0 0;\n      position: absolute;\n      left: 0;\n      top: 0;\n      border-style: none;\n    }\n</style>\n<div class=\"powerDiv\">\n    <iframe id=\"frame8675\" class=\"powerFrame\" src=\"/public/img/grafana_icon.svg\" onload=\"scale(this)\">IFRAME not supported by browser.</iframe>\n    <script>\n    document.getElementById('frame8675').parentElement.parentElement.parentElement.style.overflow = 'hidden';\n    </script>\n</div>\n<div class=\"firmwareDiv\">\n  <p class=\"version\" style=\"color:gray; text-align: bottom\">Firmware</p>\n</div>\n<script>\n// Scale Animation when Window is Resized\nfunction scale() {\n  document.querySelectorAll('.powerFrame').forEach(scaled => {\n    parent = scaled.parentNode;\n    ratio = 1.2 * Math.min((parent.offsetWidth / scaled.offsetWidth), (parent.offsetHeight / scaled.offsetHeight));\n    if (ratio > 1.0) ratio = 1.0;\n    scaled.style.transform = 'scale(' + ratio + ')  translate(-50%, -50%)';\n    scaled.style.transformOrigin = 'top left';\n  })\n}\nwindow.addEventListener('resize', function(e){ scale(); }, false);\n\n// Display Firmware Version\nfunction showversion() {\n    var pwver = window.location.protocol + \"//\" + window.location.hostname + \":8675/version\";\n    $.getJSON(pwver, function(data) {\n        var text = `Firmware: ${data.version.split(\" \")[0]}`;\n        $(\".version\").html(text);\n    });\n    setTimeout(showversion, 60000);\n}\nshowversion();\n\n// Load Animation from pyPowerwall\nvar pwurl = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\ndocument.getElementById('frame8675').src = pwurl;\n\n</script>",
         "mode": "html"
       },
       "pluginVersion": "9.1.2",
@@ -9648,6 +9648,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzV",
-  "version": 31,
+  "version": 39,
   "weekStart": ""
 }


### PR DESCRIPTION
The power flow animation is rendered in a fixed iFrame in the Grafana HTML panel but will clip as the browser window shrinks too small. Credit to [@dkerr64](https://github.com/dkerr64) for the research and updated code to auto-resize the animation based on the screen size.

See discussion #216 - Code review and feedback appreciated.

HTML in Panel:

```html
<style>
.powerDiv {
      width: 100%;
      height: 100%;
      position: absolute;
      left: 50%;
      top: 50%;
    }
.firmwareDiv {
      width: 100%;
      position: absolute;
      text-align: center;
      left: 0%;
      bottom: 0%;
    }
.powerFrame {
      width: 500px;
      height: 300px;
      transform: scale(0);
      transform-origin: 0 0;
      position: absolute;
      left: 0;
      top: 0;
      border-style: none;
    }
</style>
<div class="powerDiv">
    <iframe id="frame8675" class="powerFrame" src="/public/img/grafana_icon.svg" onload="scale(this)">IFRAME not supported by browser.</iframe>
    <script>
    document.getElementById('frame8675').parentElement.parentElement.parentElement.style.overflow = 'hidden';
    </script>
</div>
<div class="firmwareDiv">
  <p class="version" style="color:gray; text-align: bottom">Firmware</p>
</div>
<script>
// Scale Animation when Window is Resized
function scale() {
  document.querySelectorAll('.powerFrame').forEach(scaled => {
    parent = scaled.parentNode;
    ratio = 1.2 * Math.min((parent.offsetWidth / scaled.offsetWidth), (parent.offsetHeight / scaled.offsetHeight));
    if (ratio > 1.0) ratio = 1.0;
    scaled.style.transform = 'scale(' + ratio + ')  translate(-50%, -50%)';
    scaled.style.transformOrigin = 'top left';
  })
}
window.addEventListener('resize', function(e){ scale(); }, false);

// Display Firmware Version
function showversion() {
    var pwver = window.location.protocol + "//" + window.location.hostname + ":8675/version";
    $.getJSON(pwver, function(data) {
        var text = `Firmware: ${data.version.split(" ")[0]}`;
        $(".version").html(text);
    });
    setTimeout(showversion, 60000);
}
showversion();

// Load Animation from pyPowerwall
var pwurl = window.location.protocol + "//" + window.location.hostname + ":8675/";
document.getElementById('frame8675').src = pwurl;

</script>
```