### PR TITLE
Make costs/credit per kWh and timezone to be variables in Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: It can take a while for InfluxDB to start.  Also the influxdb.sql file is 
 
 ### Notes
 
-* The database queries and dashboard are set to use `America/Los_Angeles` as the timezone. Remember to edit the database commands [influxdb.sql](influxdb/influxdb.sql), [powerwall.yml](powerwall.yml), and [dashboard.json](dashboard.json) to replace `America/Los_Angeles` with your own timezone.
+* The database queries are set to use `America/Los_Angeles` as the timezone. Remember to edit the database commands [influxdb.sql](influxdb/influxdb.sql) and [powerwall.yml](powerwall.yml) with your own timezone. During import of dashboards into Grafana you'll be prompted to enter your timezone for queries.
 
 ### Upgrading
 
@@ -192,7 +192,7 @@ If you are getting permission errors running docker, or an error that it isn't i
 
 #### Savings Errors
 
-The savings estimates are based on a $0.19/kWh utility cost and net metering credit. You likely have a different value for this and can edit the queries in that panel to reflect your actual costs and credits.  To help, here are the variables used to calculate the savings:
+The savings estimates are based on a $0.19/kWh (by default) utility cost and net metering credit. You likely have a different value for this and during importing dashboards indicate your average cost per kWh to reflect your actual costs and credits. As of now there's one variable to set both cost and credit per kWh. To help, here are the variables used to calculate the savings:
 
 * `s` = kWh from solar (based on time frame selected)
 * `fp` = kWh from powerwall

--- a/dashboard.json
+++ b/dashboard.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "Cost per kWh",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -614,7 +628,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -707,7 +721,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -752,7 +766,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -1063,7 +1077,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1082,7 +1096,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -1113,7 +1127,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1144,7 +1158,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -1260,7 +1274,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2221,7 +2235,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2233,7 +2247,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -2245,7 +2259,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -2257,7 +2271,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -2358,7 +2372,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles')))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz')))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2399,7 +2413,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -2412,7 +2426,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -2437,7 +2451,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -2747,7 +2761,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2882,7 +2896,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3011,7 +3025,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3148,7 +3162,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -3197,7 +3211,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3359,7 +3373,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home",
@@ -3408,7 +3422,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid",
@@ -3434,7 +3448,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/Los_Angeles')",
+          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -3459,7 +3473,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -11449,7 +11463,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "Cost per kWh",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",
@@ -11472,6 +11529,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzV",
-  "version": 43,
+  "version": 44,
   "weekStart": ""
 }

--- a/dashboards/dashboard-animation.json
+++ b/dashboards/dashboard-animation.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -235,7 +249,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -254,7 +268,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Solar Energy",
@@ -291,7 +305,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Powerwall",
@@ -311,7 +325,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -330,7 +344,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -356,7 +370,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -375,7 +389,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -426,7 +440,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "datasource": {
@@ -630,7 +644,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -649,7 +663,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -680,7 +694,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -711,7 +725,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -827,7 +841,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -985,7 +999,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Home Usage",
@@ -1088,7 +1102,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Solar Energy",
@@ -1191,7 +1205,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Powerwall",
@@ -1294,7 +1308,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Powerwall",
@@ -1397,7 +1411,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Grid",
@@ -1500,7 +1514,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Grid",
@@ -1582,7 +1596,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1594,7 +1608,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -1606,7 +1620,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -1618,7 +1632,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -1719,7 +1733,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1760,7 +1774,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1798,7 +1812,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -2108,7 +2122,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2243,7 +2257,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2372,7 +2386,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2509,7 +2523,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -2558,7 +2572,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2710,7 +2724,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home Usage",
@@ -2759,7 +2773,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -8411,7 +8425,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",
@@ -8434,6 +8491,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzU",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboards/dashboard-grid.json
+++ b/dashboards/dashboard-grid.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -240,7 +254,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -259,7 +273,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Solar Energy",
@@ -296,7 +310,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Powerwall",
@@ -316,7 +330,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -335,7 +349,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -361,7 +375,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -380,7 +394,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -431,7 +445,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "datasource": {
@@ -514,7 +528,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -533,7 +547,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -564,7 +578,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -595,7 +609,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -684,7 +698,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"raw\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"raw\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -804,7 +818,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Home Usage",
@@ -907,7 +921,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Solar Energy",
@@ -1010,7 +1024,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Powerwall",
@@ -1113,7 +1127,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Powerwall",
@@ -1216,7 +1230,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Grid",
@@ -1319,7 +1333,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Grid",
@@ -1401,7 +1415,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1413,7 +1427,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -1425,7 +1439,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -1437,7 +1451,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -1538,7 +1552,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1579,7 +1593,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1617,7 +1631,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -1927,7 +1941,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2062,7 +2076,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2191,7 +2205,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2328,7 +2342,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -2377,7 +2391,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2529,7 +2543,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home Usage",
@@ -2578,7 +2592,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -6955,7 +6969,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",
@@ -6978,6 +7035,6 @@
   "timezone": "browser",
   "title": "Powerwall Flow and Grid",
   "uid": "RSabAvRRzUG",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/dashboards/dashboard-min-mean-max.json
+++ b/dashboards/dashboard-min-mean-max.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -991,7 +1005,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "L",
           "resultFormat": "time_series",
@@ -1029,7 +1043,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "M",
           "resultFormat": "time_series",
@@ -1067,7 +1081,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "N",
           "resultFormat": "time_series",
@@ -1105,7 +1119,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "O",
           "resultFormat": "time_series",
@@ -1162,7 +1176,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Powerwall Min",
@@ -1201,7 +1215,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage Min",
@@ -1246,7 +1260,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage Max",
@@ -1291,7 +1305,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home Usage",
@@ -1311,7 +1325,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1404,7 +1418,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -1449,7 +1463,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Energy Usage",
@@ -1490,7 +1504,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1509,7 +1523,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -1540,7 +1554,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1571,7 +1585,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -1687,7 +1701,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2648,7 +2662,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2660,7 +2674,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -2672,7 +2686,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -2684,7 +2698,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -2785,7 +2799,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles')))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz')))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2826,7 +2840,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -2839,7 +2853,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -2864,7 +2878,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -3174,7 +3188,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3309,7 +3323,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3438,7 +3452,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3575,7 +3589,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -3624,7 +3638,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3786,7 +3800,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home",
@@ -3835,7 +3849,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid",
@@ -3861,7 +3875,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/Los_Angeles')",
+          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -3886,7 +3900,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -10045,7 +10059,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-7d",
@@ -10068,6 +10125,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzU",
-  "version": 32,
+  "version": 33,
   "weekStart": ""
 }

--- a/dashboards/dashboard-new.json
+++ b/dashboards/dashboard-new.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -563,7 +577,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -656,7 +670,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -701,7 +715,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -966,7 +980,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -985,7 +999,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -1016,7 +1030,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1047,7 +1061,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -1163,7 +1177,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1218,7 +1232,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 15
       },
       "id": 41,
       "panels": [],
@@ -1912,7 +1926,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -1924,7 +1938,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -1936,7 +1950,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -1948,7 +1962,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -2049,7 +2063,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2090,7 +2104,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -2128,7 +2142,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -2438,7 +2452,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2573,7 +2587,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2702,7 +2716,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2839,7 +2853,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -2888,7 +2902,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3040,7 +3054,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home Usage",
@@ -3089,7 +3103,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -8741,7 +8755,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",
@@ -8764,6 +8821,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzU",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }

--- a/dashboards/dashboard-no-animation.json
+++ b/dashboards/dashboard-no-animation.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -206,7 +220,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -225,7 +239,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Solar Energy",
@@ -262,7 +276,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Powerwall",
@@ -282,7 +296,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -301,7 +315,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -327,7 +341,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -346,7 +360,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -397,7 +411,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "datasource": {
@@ -539,7 +553,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Powerwall",
@@ -603,7 +617,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -644,7 +658,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -682,7 +696,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -765,7 +779,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -777,7 +791,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -789,7 +803,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -801,7 +815,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -1138,7 +1152,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Home Usage",
@@ -1241,7 +1255,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Powerwall",
@@ -1344,7 +1358,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Grid",
@@ -1448,7 +1462,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Solar Energy",
@@ -1551,7 +1565,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Powerwall",
@@ -1654,7 +1668,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Grid",
@@ -1766,7 +1780,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -1901,7 +1915,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2030,7 +2044,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2167,7 +2181,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -2216,7 +2230,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2368,7 +2382,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home Usage",
@@ -2417,7 +2431,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -7423,7 +7437,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",

--- a/dashboards/dashboard-simple.json
+++ b/dashboards/dashboard-simple.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "kWh cost",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -219,7 +233,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -238,7 +252,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Solar Energy",
@@ -275,7 +289,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Powerwall",
@@ -295,7 +309,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_pw) - mean(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -314,7 +328,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -340,7 +354,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('America/Los_Angeles')",
+          "query": "SELECT mean(from_grid) - mean(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time(5m) tz('$tz')",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -359,7 +373,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -410,7 +424,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "datasource": {
@@ -547,7 +561,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Powerwall",
@@ -626,7 +640,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -680,7 +694,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -716,7 +730,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-powered",
@@ -814,7 +828,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -857,7 +871,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -900,7 +914,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -927,7 +941,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -1261,7 +1275,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Home Usage",
@@ -1364,7 +1378,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Powerwall",
@@ -1467,7 +1481,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "From Grid",
@@ -1570,7 +1584,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Solar Energy",
@@ -1673,7 +1687,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Powerwall",
@@ -1776,7 +1790,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "To Grid",
@@ -1901,7 +1915,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2034,7 +2048,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2161,7 +2175,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2295,7 +2309,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -2344,7 +2358,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2484,7 +2498,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2525,7 +2539,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "kWh cost",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now/d",

--- a/dashboards/dashboard.json
+++ b/dashboards/dashboard.json
@@ -15,6 +15,20 @@
       "type": "datasource",
       "pluginId": "fetzerch-sunandmoon-datasource",
       "pluginName": "Sun and Moon"
+    },
+    {
+      "name": "VAR_AVG_PER_KWH",
+      "type": "constant",
+      "label": "Cost per kWh",
+      "value": "0.19",
+      "description": ""
+    },
+    {
+      "name": "VAR_TZ",
+      "type": "constant",
+      "label": "Timezone",
+      "value": "America/Los_Angeles",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -614,7 +628,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('America/Los_Angeles')",
+          "query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -707,7 +721,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid Usage",
@@ -752,7 +766,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Charge",
@@ -1063,7 +1077,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1082,7 +1096,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Powerwall",
@@ -1113,7 +1127,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -1144,7 +1158,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Power Flow",
@@ -1260,7 +1274,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('America/Los_Angeles')",
+          "query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) tz('$tz')",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2221,7 +2235,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2233,7 +2247,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * 0.19 AS s,  sum(\"to_pw\")  * 0.19 AS tp, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_per_kwh AS s,  sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series"
@@ -2245,7 +2259,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series"
@@ -2257,7 +2271,7 @@
             "uid": "${DS_INFLUXDB}"
           },
           "hide": false,
-          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * 0.19 AS tp, sum(\"solar\") * 0.19 AS s, sum(\"to_grid\") * 0.19 AS tg, sum(\"from_pw\") * 0.19 AS fp FROM kwh.http WHERE  $timeFilter tz('America/Los_Angeles'))\n",
+          "query": "SELECT tg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_per_kwh AS tp, sum(\"solar\") * $avg_per_kwh AS s, sum(\"to_grid\") * $avg_per_kwh AS tg, sum(\"from_pw\") * $avg_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series"
@@ -2358,7 +2372,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles')))",
+          "query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz')))",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"
@@ -2399,7 +2413,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "From Grid",
@@ -2412,7 +2426,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('America/Los_Angeles'))",
+          "query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz'))",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -2437,7 +2451,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "title": "Self-Powered",
@@ -2747,7 +2761,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -2882,7 +2896,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3011,7 +3025,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3148,7 +3162,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "To Grid",
@@ -3197,7 +3211,7 @@
             ]
           ],
           "tags": [],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -3359,7 +3373,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Home",
@@ -3408,7 +3422,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         },
         {
           "alias": "Grid",
@@ -3434,7 +3448,7 @@
           "measurement": "http",
           "orderByTime": "ASC",
           "policy": "kwh",
-          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('America/Los_Angeles')",
+          "query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('$tz')",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -3459,7 +3473,7 @@
               "value": "0"
             }
           ],
-          "tz": "America/Los_Angeles"
+          "tz": "$tz"
         }
       ],
       "thresholds": [],
@@ -11449,7 +11463,50 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "description": "Average Cost Per kWh",
+        "hide": 2,
+        "label": "Cost per kWh",
+        "name": "avg_per_kwh",
+        "query": "${VAR_AVG_PER_KWH}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_AVG_PER_KWH}",
+          "text": "${VAR_AVG_PER_KWH}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_AVG_PER_KWH}",
+            "text": "${VAR_AVG_PER_KWH}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "description": "Timezone",
+        "hide": 2,
+        "label": "Timezone",
+        "name": "tz",
+        "query": "${VAR_TZ}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_TZ}",
+          "text": "${VAR_TZ}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_TZ}",
+            "text": "${VAR_TZ}",
+            "selected": false
+          }
+        ]
+      }
+    ]
   },
   "time": {
     "from": "now-24h",
@@ -11472,6 +11529,6 @@
   "timezone": "browser",
   "title": "Powerwall Power Flow",
   "uid": "RSabAvRRzV",
-  "version": 43,
+  "version": 44,
   "weekStart": ""
 }


### PR DESCRIPTION
This closes #263 

However, I do not differentiate between costs and credits here, assuming both are same. I do understand that buying electricity may include delivery costs, which you probably don't get compensated for when you export electricity, so as part of further improvements, we can set up two variables: price per kWh when you import (buy) and price per kWh when you export (sell) and use them accordingly in the queries. This is up for discussion.

Now, when you import a dashboard, you get prompted like this:

![image](https://user-images.githubusercontent.com/4997180/235833814-8aca9a68-a892-479c-875a-52bcd28f4091.png)


Second thing: there's too many dashboards in the repository, I got confused a bit, and edited only those that I kinda use or understand what they are. Hopefully it's good enough for starters.