### PR TITLE
Add InfluxDB PORT by env variable to tesla-history

### DIFF
--- a/tools/solar-only/powerwall.yml
+++ b/tools/solar-only/powerwall.yml
@@ -59,17 +59,19 @@ services:
             - influxdb
 
     tesla-history:
-        image: jasonacox/tesla-history:0.1.0
+        image: jasonacox/tesla-history:0.1.1
         container_name: tesla-history
         hostname: tesla-history
         restart: always
+        user: "1000:1000"
         volumes:
             - type: bind
               source: ./tesla-history
               target: /var/lib/tesla-history
         environment:
-            - IHOST=influxdb
-            - TCONF=/var/lib/tesla-history/tesla-history.conf
-            - TAUTH=/var/lib/tesla-history/tesla-history.auth
+            - INFLUX_HOST=influxdb
+            - INFLUX_PORT=8086
+            - TESLA_CONF=/var/lib/tesla-history/tesla-history.conf
+            - TESLA_AUTH=/var/lib/tesla-history/tesla-history.auth
         depends_on:
             - influxdb

--- a/tools/solar-only/setup.sh
+++ b/tools/solar-only/setup.sh
@@ -142,7 +142,7 @@ if [ -z "${TZ}" ]; then
     TZ="${CURRENT}"
 fi
 echo "Setup tesla-history..."
-if type winpty > /dev/null; then
+if type winpty > /dev/null 2>&1; then
     # Windows special case
     winpty docker exec -it -w /var/lib/tesla-history tesla-history python3 tesla-history.py --setup --timezone "${TZ}"
 else

--- a/tools/solar-only/tesla-history/tesla-history.py
+++ b/tools/solar-only/tesla-history/tesla-history.py
@@ -57,7 +57,7 @@ try:
 except:
     sys.exit("ERROR: Missing python influxdb module. Run 'pip install influxdb'.")
 
-BUILD = "0.1.0"
+BUILD = "0.1.1"
 VERBOSE = True
 SCRIPTPATH = os.path.dirname(os.path.realpath(sys.argv[0]))
 SCRIPTNAME = os.path.basename(sys.argv[0]).split('.')[0]
@@ -138,7 +138,7 @@ if args.config:
 
 if args.daemon:
     # Get config file from environment variable if defined
-    CONFIGNAME = CONFIGFILE = os.getenv('TCONF', CONFIGNAME)
+    CONFIGNAME = CONFIGFILE = os.getenv('TESLA_CONF', CONFIGNAME)
 
 # Load Configuration File
 config = configparser.ConfigParser(allow_no_value=True)
@@ -180,8 +180,9 @@ if os.path.exists(CONFIGFILE):
 
         # Get settings when running as a daemon
         if args.daemon:
-            IHOST = os.getenv('IHOST', IHOST)
-            TAUTH = os.getenv('TAUTH', TAUTH)
+            IHOST = os.getenv('INFLUX_HOST', IHOST)
+            IPORT = os.getenv('INFLUX_PORT', IPORT)
+            TAUTH = os.getenv('TESLA_AUTH', TAUTH)
             WAIT = config.getint('daemon', 'WAIT', fallback=5)
             HIST = config.getint('daemon', 'HIST', fallback=60)
             SITE = config.getint('daemon', 'SITE', fallback=None)


### PR DESCRIPTION
Added support to tesla-history script to define the InfluxDB PORT by environment variable for when running in a docker container per #183 

Jason - please push latest script build "0.1.1" to Docker Hub when you have chance, thanks!

Also fixed a few other issues I noticed, as follows:

* There was error output during execution of the setup script - the "type" command must output to stderr, so stderr has been redirected to null

```bash
./setup.sh: line 145: type: winpty: not found
```

* Changed the environment variable names for the tesla-history container to be more descriptive
* Added "user" (uid:gid) for tesla-history docker container as per how weather411 is configured
  * I had tried to edit the tesla-history.conf file, which was created during the setup process, however it was owned by "root" and could not be edited without first changing the owner
  * Perhaps the "user" configuration for tesla-history & weather411 should be configured via the compose.env file variable similar to grafana, instead of hard coding the uid:gid? e.g. ${GRAFANAUSER} - maybe even use the same variable?