### PR TITLE
Fix tesla daemon to replace data instead of update

### DIFF
--- a/tools/solar-only/powerwall.yml
+++ b/tools/solar-only/powerwall.yml
@@ -59,7 +59,7 @@ services:
             - influxdb
 
     tesla-history:
-        image: jasonacox/tesla-history:0.1.1
+        image: jasonacox/tesla-history:0.1.2
         container_name: tesla-history
         hostname: tesla-history
         restart: always

--- a/tools/solar-only/tesla-history/Dockerfile
+++ b/tools/solar-only/tesla-history/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 WORKDIR /app
 RUN pip3 install python-dateutil teslapy influxdb
 COPY tesla-history.py tesla-history.py


### PR DESCRIPTION
Update to tesla-history docker container to address issue noted by @youzer-name in #286 

@jasonacox - Please push to Docker Hub when you have a chance, thanks!

Changes as follows:

- Script will now remove previously written data before writing new data, instead of updating the data points in InfluxDB. This should address the issue where previously returned timestamps are not returned in subsequent calls for history data, which would result in zero values being seen in production graphs
- Updated the docker container to use Python 3.11 which is now released in alpine 3.18 (stable) - noting "Python 3.11 is between 10-60% faster than Python 3.10"