### PR TITLE
create dashboard-new

### DIFF
--- a/dashboards/dashboard-new.json
+++ b/dashboards/dashboard-new.json
@@ -1,0 +1,9339 @@
+{
+	"__inputs": [
+		{
+			"name": "DS_INFLUXDB",
+			"label": "InfluxDB",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "influxdb",
+			"pluginName": "InfluxDB"
+		},
+		{
+			"name": "DS_SUN_AND MOON",
+			"label": "Sun and Moon",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "fetzerch-sunandmoon-datasource",
+			"pluginName": "Sun and Moon"
+		},
+		{
+			"name": "VAR_AVG_BUY_PER_KWH",
+			"type": "constant",
+			"label": "Buy Cost per kWh",
+			"value": "0.19",
+			"description": ""
+		},
+		{
+			"name": "VAR_AVG_SELL_PER_KWH",
+			"type": "constant",
+			"label": "Sell Cost per kWh",
+			"value": "0.19",
+			"description": ""
+		},
+		{
+			"name": "VAR_TZ",
+			"type": "constant",
+			"label": "Timezone",
+			"value": "America/Los_Angeles",
+			"description": ""
+		}
+	],
+	"__elements": {
+		"XB8yzeRgk": {
+			"name": "Grid Status",
+			"uid": "XB8yzeRgk",
+			"kind": 1,
+			"model": {
+				"alert": {
+					"alertRuleTags": {},
+					"conditions": [
+						{
+							"evaluator": {
+								"params": [
+									1
+								],
+								"type": "lt"
+							},
+							"operator": {
+								"type": "and"
+							},
+							"query": {
+								"params": [
+									"A",
+									"5m",
+									"now"
+								]
+							},
+							"reducer": {
+								"params": [],
+								"type": "avg"
+							},
+							"type": "query"
+						}
+					],
+					"executionErrorState": "alerting",
+					"for": "5m",
+					"frequency": "1m",
+					"handler": 1,
+					"message": "Grid Offline",
+					"name": "Grid Status alert",
+					"noDataState": "keep_state",
+					"notifications": []
+				},
+				"datasource": {
+					"type": "influxdb",
+					"uid": "${DS_INFLUXDB}"
+				},
+				"description": "",
+				"fieldConfig": {
+					"defaults": {
+						"color": {
+							"fixedColor": "green",
+							"mode": "fixed"
+						},
+						"custom": {
+							"axisCenteredZero": false,
+							"axisColorMode": "text",
+							"axisLabel": "",
+							"axisPlacement": "auto",
+							"barAlignment": 0,
+							"drawStyle": "line",
+							"fillOpacity": 61,
+							"gradientMode": "none",
+							"hideFrom": {
+								"legend": false,
+								"tooltip": false,
+								"viz": false
+							},
+							"lineInterpolation": "linear",
+							"lineWidth": 0,
+							"pointSize": 5,
+							"scaleDistribution": {
+								"type": "linear"
+							},
+							"showPoints": "never",
+							"spanNulls": false,
+							"stacking": {
+								"group": "A",
+								"mode": "none"
+							},
+							"thresholdsStyle": {
+								"mode": "off"
+							}
+						},
+						"links": [],
+						"mappings": [],
+						"thresholds": {
+							"mode": "absolute",
+							"steps": [
+								{
+									"color": "green",
+									"value": null
+								}
+							]
+						},
+						"unit": "none"
+					},
+					"overrides": [
+						{
+							"matcher": {
+								"id": "byName",
+								"options": "off_grid"
+							},
+							"properties": [
+								{
+									"id": "color",
+									"value": {
+										"fixedColor": "red",
+										"mode": "fixed"
+									}
+								},
+								{
+									"id": "custom.hideFrom",
+									"value": {
+										"legend": true,
+										"tooltip": true,
+										"viz": false
+									}
+								},
+								{
+									"id": "custom.axisPlacement",
+									"value": "hidden"
+								}
+							]
+						},
+						{
+							"matcher": {
+								"id": "byName",
+								"options": "Grid Status"
+							},
+							"properties": [
+								{
+									"id": "custom.axisPlacement",
+									"value": "hidden"
+								},
+								{
+									"id": "mappings",
+									"value": [
+										{
+											"options": {
+												"0": {
+													"index": 1,
+													"text": "Off Grid"
+												},
+												"1": {
+													"index": 0,
+													"text": "On Grid"
+												}
+											},
+											"type": "value"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				"hideTimeOverride": false,
+				"interval": "",
+				"options": {
+					"legend": {
+						"calcs": [],
+						"displayMode": "list",
+						"placement": "bottom",
+						"showLegend": false
+					},
+					"tooltip": {
+						"mode": "multi",
+						"sort": "none"
+					}
+				},
+				"pluginVersion": "9.1.2",
+				"targets": [
+					{
+						"alias": "Grid Status",
+						"datasource": {
+							"type": "influxdb",
+							"uid": "${DS_INFLUXDB}"
+						},
+						"groupBy": [
+							{
+								"params": [
+									"$__interval"
+								],
+								"type": "time"
+							},
+							{
+								"params": [
+									"0"
+								],
+								"type": "fill"
+							}
+						],
+						"measurement": "http",
+						"orderByTime": "ASC",
+						"policy": "raw",
+						"query": "SELECT min(\"grid_status\") FROM \"grid\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(previous) tz('America/New_York')",
+						"rawQuery": true,
+						"refId": "A",
+						"resultFormat": "time_series",
+						"select": [
+							[
+								{
+									"params": [
+										"grid_status"
+									],
+									"type": "field"
+								},
+								{
+									"params": [],
+									"type": "sum"
+								}
+							]
+						],
+						"tags": [],
+						"tz": "America/Los_Angeles"
+					},
+					{
+						"alias": "off_grid",
+						"datasource": {
+							"type": "influxdb",
+							"uid": "${DS_INFLUXDB}"
+						},
+						"hide": false,
+						"query": "SELECT min(\"grid_status\") + 1 FROM \"grid\".\"http\" WHERE grid_status = 0 and $timeFilter GROUP BY time($__interval) fill(null) tz('America/New_York')",
+						"rawQuery": true,
+						"refId": "B",
+						"resultFormat": "time_series"
+					}
+				],
+				"title": "Grid Status",
+				"type": "timeseries"
+			}
+		},
+		"urTr7ciRk": {
+			"name": "Solar Energy Year",
+			"uid": "urTr7ciRk",
+			"kind": 1,
+			"model": {
+				"datasource": {
+					"type": "influxdb",
+					"uid": "${DS_INFLUXDB}"
+				},
+				"description": "",
+				"fieldConfig": {
+					"defaults": {
+						"color": {
+							"mode": "palette-classic"
+						},
+						"custom": {
+							"axisCenteredZero": false,
+							"axisColorMode": "text",
+							"axisLabel": "",
+							"axisPlacement": "auto",
+							"barAlignment": 0,
+							"drawStyle": "bars",
+							"fillOpacity": 100,
+							"gradientMode": "none",
+							"hideFrom": {
+								"legend": false,
+								"tooltip": false,
+								"viz": false
+							},
+							"lineInterpolation": "linear",
+							"lineWidth": 1,
+							"pointSize": 5,
+							"scaleDistribution": {
+								"type": "linear"
+							},
+							"showPoints": "never",
+							"spanNulls": false,
+							"stacking": {
+								"group": "A",
+								"mode": "none"
+							},
+							"thresholdsStyle": {
+								"mode": "off"
+							}
+						},
+						"links": [],
+						"mappings": [],
+						"thresholds": {
+							"mode": "absolute",
+							"steps": [
+								{
+									"color": "green"
+								}
+							]
+						},
+						"unit": "kwatth"
+					},
+					"overrides": [
+						{
+							"matcher": {
+								"id": "byName",
+								"options": "Solar"
+							},
+							"properties": [
+								{
+									"id": "color",
+									"value": {
+										"fixedColor": "yellow",
+										"mode": "fixed"
+									}
+								}
+							]
+						},
+						{
+							"matcher": {
+								"id": "byName",
+								"options": "Home Usage"
+							},
+							"properties": [
+								{
+									"id": "color",
+									"value": {
+										"fixedColor": "#3274D9",
+										"mode": "fixed"
+									}
+								},
+								{
+									"id": "custom.drawStyle",
+									"value": "line"
+								},
+								{
+									"id": "custom.fillOpacity",
+									"value": 0
+								},
+								{
+									"id": "custom.lineWidth",
+									"value": 1
+								},
+								{
+									"id": "custom.lineInterpolation",
+									"value": "stepAfter"
+								}
+							]
+						},
+						{
+							"matcher": {
+								"id": "byName",
+								"options": "Grid Usage"
+							},
+							"properties": [
+								{
+									"id": "color",
+									"value": {
+										"fixedColor": "purple",
+										"mode": "fixed"
+									}
+								},
+								{
+									"id": "custom.lineWidth",
+									"value": 1
+								},
+								{
+									"id": "custom.lineInterpolation",
+									"value": "stepAfter"
+								},
+								{
+									"id": "custom.drawStyle",
+									"value": "line"
+								},
+								{
+									"id": "custom.fillOpacity",
+									"value": 0
+								}
+							]
+						}
+					]
+				},
+				"options": {
+					"legend": {
+						"calcs": [
+							"mean",
+							"max"
+						],
+						"displayMode": "table",
+						"placement": "right",
+						"showLegend": true
+					},
+					"tooltip": {
+						"mode": "multi",
+						"sort": "none"
+					}
+				},
+				"pluginVersion": "9.1.2",
+				"targets": [
+					{
+						"alias": "Home Usage",
+						"datasource": {
+							"type": "influxdb",
+							"uid": "${DS_INFLUXDB}"
+						},
+						"groupBy": [
+							{
+								"params": [
+									"1d"
+								],
+								"type": "time"
+							},
+							{
+								"params": [
+									"null"
+								],
+								"type": "fill"
+							}
+						],
+						"hide": false,
+						"measurement": "http",
+						"orderByTime": "ASC",
+						"policy": "kwh",
+						"query": "SELECT sum(\"home\") FROM \"kwh\".\"http\" WHERE (\"home\" > 0) GROUP BY time(1d) fill(null)",
+						"rawQuery": true,
+						"refId": "B",
+						"resultFormat": "time_series",
+						"select": [
+							[
+								{
+									"params": [
+										"home"
+									],
+									"type": "field"
+								},
+								{
+									"params": [],
+									"type": "sum"
+								}
+							]
+						],
+						"tags": [
+							{
+								"key": "home",
+								"operator": ">",
+								"value": "0"
+							}
+						]
+					},
+					{
+						"alias": "Solar",
+						"datasource": {
+							"type": "influxdb",
+							"uid": "${DS_INFLUXDB}"
+						},
+						"groupBy": [
+							{
+								"params": [
+									"1d"
+								],
+								"type": "time"
+							},
+							{
+								"params": [
+									"null"
+								],
+								"type": "fill"
+							}
+						],
+						"hide": false,
+						"measurement": "http",
+						"orderByTime": "ASC",
+						"policy": "kwh",
+						"query": "SELECT sum(\"solar\") FROM \"kwh\".\"http\" WHERE (\"solar\" > 0) GROUP BY time(1d) fill(0)",
+						"rawQuery": true,
+						"refId": "A",
+						"resultFormat": "time_series",
+						"select": [
+							[
+								{
+									"params": [
+										"solar"
+									],
+									"type": "field"
+								},
+								{
+									"params": [],
+									"type": "sum"
+								}
+							]
+						],
+						"tags": [
+							{
+								"key": "solar",
+								"operator": ">",
+								"value": "0"
+							}
+						]
+					},
+					{
+						"alias": "Grid Usage",
+						"datasource": {
+							"type": "influxdb",
+							"uid": "${DS_INFLUXDB}"
+						},
+						"hide": false,
+						"query": "SELECT sum(\"from_grid\") - sum(\"to_grid\") as \"grid\" FROM \"kwh\".\"http\" WHERE $timeFilter GROUP BY time(1d) fill(0) tz('$tz')",
+						"rawQuery": true,
+						"refId": "C",
+						"resultFormat": "time_series"
+					}
+				],
+				"timeFrom": "12M",
+				"title": "Solar Energy Year",
+				"type": "timeseries"
+			}
+		}
+	},
+	"__requires": [
+		{
+			"type": "datasource",
+			"id": "fetzerch-sunandmoon-datasource",
+			"name": "Sun and Moon",
+			"version": "0.3.0"
+		},
+		{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "9.1.2"
+		},
+		{
+			"type": "panel",
+			"id": "grafana-piechart-panel",
+			"name": "Pie Chart (old)",
+			"version": "1.6.4"
+		},
+		{
+			"type": "panel",
+			"id": "graph",
+			"name": "Graph (old)",
+			"version": ""
+		},
+		{
+			"type": "datasource",
+			"id": "influxdb",
+			"name": "InfluxDB",
+			"version": "1.0.0"
+		},
+		{
+			"type": "panel",
+			"id": "stat",
+			"name": "Stat",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "state-timeline",
+			"name": "State timeline",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "text",
+			"name": "Text",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "timeseries",
+			"name": "Time series",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "yesoreyeram-boomtable-panel",
+			"name": "Boom Table",
+			"version": "1.5.0-alpha.3"
+		}
+	],
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "datasource",
+					"uid": "grafana"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"target": {
+					"limit": 100,
+					"matchAny": false,
+					"tags": [],
+					"type": "dashboard"
+				},
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"id": null,
+	"links": [],
+	"liveNow": false,
+	"panels": [
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 20,
+			"panels": [],
+			"title": "Live Monitoring",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "datasource",
+				"uid": "-- Mixed --"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": true,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 30,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "watt"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Charge"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Grid Usage"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "purple",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Home Usage"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "blue",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Powerwall"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "green",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Solar Energy"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Sun altitude"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "rgb(192, 192, 192)",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": true,
+									"tooltip": true,
+									"viz": false
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "Charge|Reserve"
+						},
+						"properties": [
+							{
+								"id": "custom.drawStyle",
+								"value": "line"
+							},
+							{
+								"id": "custom.fillOpacity",
+								"value": 0
+							},
+							{
+								"id": "custom.lineWidth",
+								"value": 0
+							},
+							{
+								"id": "custom.lineWidth",
+								"value": 2
+							},
+							{
+								"id": "unit",
+								"value": "percent"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							},
+							{
+								"id": "min",
+								"value": -101
+							},
+							{
+								"id": "max",
+								"value": 101
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Sun altitude"
+						},
+						"properties": [
+							{
+								"id": "custom.fillOpacity",
+								"value": 10
+							},
+							{
+								"id": "unit",
+								"value": "percent"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							},
+							{
+								"id": "min",
+								"value": -101
+							},
+							{
+								"id": "max",
+								"value": 101
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										1,
+										5
+									],
+									"fill": "dash"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Temperature"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#FF9830",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "custom.fillOpacity",
+								"value": 0
+							},
+							{
+								"id": "unit",
+								"value": "none"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							},
+							{
+								"id": "min",
+								"value": -101
+							},
+							{
+								"id": "max",
+								"value": 101
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										6,
+										2
+									],
+									"fill": "dash"
+								}
+							},
+							{
+								"id": "custom.axisPlacement",
+								"value": "hidden"
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Clouds"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "rgb(255, 255, 255)",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "custom.fillOpacity",
+								"value": 0
+							},
+							{
+								"id": "unit",
+								"value": "percent"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							},
+							{
+								"id": "min",
+								"value": -101
+							},
+							{
+								"id": "max",
+								"value": 101
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										5,
+										6
+									],
+									"fill": "dash"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Feels Like"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#F2CC0C",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "custom.fillOpacity",
+								"value": 0
+							},
+							{
+								"id": "unit",
+								"value": "percent"
+							},
+							{
+								"id": "decimals",
+								"value": 0
+							},
+							{
+								"id": "min",
+								"value": -101
+							},
+							{
+								"id": "max",
+								"value": 101
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										6,
+										2
+									],
+									"fill": "dash"
+								}
+							},
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": true,
+									"tooltip": true,
+									"viz": false
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Grid Down"
+						},
+						"properties": [
+							{
+								"id": "custom.axisPlacement",
+								"value": "hidden"
+							},
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "min",
+								"value": 0
+							},
+							{
+								"id": "max",
+								"value": 30
+							},
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": true,
+									"tooltip": true,
+									"viz": false
+								}
+							},
+							{
+								"id": "custom.fillOpacity",
+								"value": 24
+							},
+							{
+								"id": "custom.spanNulls",
+								"value": 120000
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Reserve"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#f2495c75",
+									"mode": "fixed"
+								}
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										10,
+										10
+									],
+									"fill": "dash"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 13,
+				"w": 16,
+				"x": 0,
+				"y": 1
+			},
+			"id": 2,
+			"interval": "",
+			"options": {
+				"legend": {
+					"calcs": [
+						"max"
+					],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Home Usage",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT \"mean_load_instant_power\" FROM \"http\" WHERE $timeFilter tz('$tz')",
+					"rawQuery": false,
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"home"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "max"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Solar Energy",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"solar"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "max"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"5m"
+							],
+							"type": "time"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT max(from_pw) - max(to_pw) FROM autogen.http WHERE $timeFilter GROUP BY time($__interval) ",
+					"rawQuery": true,
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_pw+to_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "Grid Usage",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"5m"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"none"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "default",
+					"query": "SELECT max(from_grid) - max(to_grid) FROM autogen.http WHERE $timeFilter GROUP BY time($__interval) ",
+					"rawQuery": true,
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"site_instant_power"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"none"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT \"mean_percentage\" FROM \"http\" WHERE $timeFilter",
+					"rawQuery": false,
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"percentage"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "last"
+							},
+							{
+								"params": [
+									" /0.95 - 5/0.95"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"datasource": {
+						"type": "fetzerch-sunandmoon-datasource",
+						"uid": "${DS_SUN_AND MOON}"
+					},
+					"refId": "F",
+					"target": [
+						"sun_altitude"
+					]
+				},
+				{
+					"alias": "Temperature",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "G",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"temperature"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Clouds",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "H",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"clouds"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Feels Like",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "I",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"feels_like"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid Down",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"orderByTime": "ASC",
+					"policy": "default",
+					"query": "SELECT min(\"grid_status\") +1  FROM \"grid\".\"http\" WHERE grid_status = 0 and $timeFilter GROUP BY time($__interval) ",
+					"rawQuery": true,
+					"refId": "J",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"value"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Reserve",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"none"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT \"mean_percentage\" FROM \"http\" WHERE $timeFilter",
+					"rawQuery": false,
+					"refId": "K",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"backup_reserve_percent"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "last"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Energy Usage",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"gridPos": {
+				"h": 10,
+				"w": 8,
+				"x": 16,
+				"y": 1
+			},
+			"id": 13,
+			"links": [],
+			"options": {
+				"content": "<style>\ndiv.powerDiv {\n      width: 100%;\n      height: 100%;\n      overflow: hidden;\n      background: url(public/img/load_big.gif) center center no-repeat;\n    }\ndiv.firmwareDiv {\n      width: 100%;\n      position: absolute;\n      text-align: center;\n      left: 0;\n      bottom: 0;\n      overflow: hidden;\n    }\niframe.powerFrame {\n      width: 400px;\n      height: 300px;\n      transform: scale(0);\n      transform-origin: center;\n      position: absolute;\n      left: 50%;\n      top: 50%;\n      border-style: none;\n    }\n</style>\n<div class=\"powerDiv\">\n    <iframe id=\"frame8675\" class=\"powerFrame\" src=\"/public/img/grafana_icon.svg\">IFRAME not supported by browser.</iframe>\n</div>\n<div class=\"firmwareDiv\">\n  <p class=\"version\" style=\"color:gray; text-align: center;\">Firmware</p>\n</div>\n<script>\n// Scale Animation when Window is Resized\nfunction scale() {\n  document.querySelectorAll('.powerFrame').forEach(scaled => {\n    parent = scaled.parentNode;\n    ratio = Math.min(1,parent.offsetWidth / scaled.offsetWidth, parent.offsetHeight / scaled.offsetHeight);\n    scaled.style.transform = 'translate(-50%, -50%) scale(' + ratio + ')';\n  })\n}\nwindow.addEventListener('resize', function(e){ scale(); }, false);\n\n// Display Firmware Version\nfunction showversion() {\n    var pwver = window.location.protocol + \"//\" + window.location.hostname + \":8675/version\";\n    $.getJSON(pwver, function(data) {\n        var text = `Firmware: ${data.version.split(\" \")[0]}`;\n        $(\".version\").html(text);\n    });\n    setTimeout(showversion, 60000);\n}\nshowversion();\n\n// Load Animation from pyPowerwall\nvar powerFrame = document.getElementById('frame8675');\npowerFrame.onload = function() {\n  // remove animated gif from background now that frame downloaded...\n  this.parentNode.setAttribute('style','background: none');\n  // and scale the frame to fit...\n  scale();\n}\npowerFrame.src = window.location.protocol + \"//\" + window.location.hostname + \":8675/\";\n</script>",
+				"mode": "html"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "From Solar",
+					"groupBy": [
+						{
+							"params": [
+								"1h"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"none"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "default",
+					"query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - integral(to_pw)/1000/3600 - integral(to_grid)/1000/3600  AS from_solar FROM autogen.http WHERE  $timeFilter tz('$tz'))",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"solar_5m_power"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "From Powerwall",
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "From Grid",
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				}
+			],
+			"title": "Power Flow",
+			"transparent": true,
+			"type": "text"
+		},
+		{
+			"gridPos": {
+				"h": 3,
+				"w": 6,
+				"x": 17,
+				"y": 11
+			},
+			"id": 72,
+			"libraryPanel": {
+				"uid": "XB8yzeRgk",
+				"name": "Grid Status"
+			}
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 14
+			},
+			"id": 41,
+			"panels": [],
+			"title": "Power Meters",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "blue",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 0,
+				"y": 15
+			},
+			"id": 4,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"home"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Home Usage",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "yellow",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 3,
+				"y": 15
+			},
+			"id": 5,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"solar"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Solar Energy",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "yellow",
+								"value": null
+							}
+						]
+					},
+					"unit": "percentunit"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 6,
+				"y": 15
+			},
+			"id": 70,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "/^SolarPowered$/",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "SolarPowered",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT (home - from_grid) / home FROM \n  (SELECT integral(\"home\")  AS home, integral(\"from_grid\")  AS from_grid \n      FROM \"autogen\".\"http\" WHERE $timeFilter)",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"solar"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "% Solar Powered",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "0.0 kWh"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 9,
+				"y": 15
+			},
+			"id": 8,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"to_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "To Powerwall",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 12,
+				"y": 15
+			},
+			"id": 6,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "From Powerwall",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "purple",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 15,
+				"y": 15
+			},
+			"id": 7,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"to_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "To Grid",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "purple",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 18,
+				"y": 15
+			},
+			"id": 9,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "From Grid",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"decimals": 1,
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "purple",
+								"value": null
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 2,
+				"w": 3,
+				"x": 21,
+				"y": 15
+			},
+			"id": 69,
+			"interval": "",
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": [
+						"sum"
+					],
+					"fields": "",
+					"values": false
+				},
+				"text": {
+					"valueSize": 30
+				},
+				"textMode": "auto"
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT (integral(\"from_grid\") - integral(\"to_grid\"))   / 1000 / 3600 FROM \"autogen\".\"http\" WHERE $timeFilter",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Net Grid Usage",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"aliasColors": {
+				"battery": "green",
+				"battery impact": "green",
+				"combined": "red",
+				"solar": "yellow",
+				"solar + battery": "red",
+				"solar > grid": "purple",
+				"solar > home": "yellow",
+				"solar only": "yellow",
+				"total": "blue"
+			},
+			"bars": true,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"decimals": 2,
+			"description": "Estimated Savings",
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 5,
+				"w": 9,
+				"x": 0,
+				"y": 17
+			},
+			"hiddenSeries": false,
+			"hideTimeOverride": true,
+			"id": 45,
+			"interval": "",
+			"legend": {
+				"alignAsTable": true,
+				"avg": false,
+				"current": false,
+				"hideEmpty": false,
+				"hideZero": true,
+				"max": false,
+				"min": false,
+				"rightSide": true,
+				"show": true,
+				"total": true,
+				"values": true
+			},
+			"lines": false,
+			"linewidth": 1,
+			"links": [],
+			"nullPointMode": "null",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "9.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"alias": "powerwall > home",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"query": "SELECT fp FROM (SELECT sum(\"from_pw\")  * $avg_buy_per_kwh AS fp FROM kwh.http WHERE  $timeFilter tz('$tz'))",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series"
+				},
+				{
+					"alias": "solar > home",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"hide": false,
+					"query": "SELECT s - (tp + tg) FROM (SELECT sum(\"solar\") * $avg_buy_per_kwh AS s,  sum(\"to_pw\")  * $avg_buy_per_kwh AS tp, sum(\"to_grid\") * $avg_buy_per_kwh AS tg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
+					"rawQuery": true,
+					"refId": "B",
+					"resultFormat": "time_series"
+				},
+				{
+					"alias": "solar > grid",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"hide": false,
+					"query": "SELECT tgg FROM (SELECT sum(\"to_grid\") * $avg_sell_per_kwh AS tgg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
+					"rawQuery": true,
+					"refId": "C",
+					"resultFormat": "time_series"
+				},
+				{
+					"alias": "total",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"hide": false,
+					"query": "SELECT tgg + (s - tp - tg ) + fp FROM (SELECT sum(\"to_pw\")  * $avg_buy_per_kwh AS tp, sum(\"solar\") * $avg_buy_per_kwh AS s, sum(\"to_grid\") * $avg_buy_per_kwh AS tg, sum(\"from_pw\") * $avg_buy_per_kwh AS fp, sum(\"to_grid\") * $avg_sell_per_kwh AS tgg FROM kwh.http WHERE  $timeFilter tz('$tz'))\n",
+					"rawQuery": true,
+					"refId": "D",
+					"resultFormat": "time_series"
+				}
+			],
+			"thresholds": [],
+			"timeRegions": [],
+			"title": "Savings",
+			"tooltip": {
+				"shared": false,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"mode": "series",
+				"show": false,
+				"values": [
+					"total"
+				]
+			},
+			"yaxes": [
+				{
+					"$$hashKey": "object:1096",
+					"decimals": 2,
+					"format": "currencyUSD",
+					"label": "",
+					"logBase": 1,
+					"min": "0",
+					"show": true
+				},
+				{
+					"$$hashKey": "object:1097",
+					"format": "short",
+					"logBase": 1,
+					"show": false
+				}
+			],
+			"yaxis": {
+				"align": false
+			}
+		},
+		{
+			"aliasColors": {
+				"Battery": "#73BF69",
+				"Battery Usage": "#73BF69",
+				"From Grid": "#B877D9",
+				"From Powerwall": "#73BF69",
+				"From Solar": "#FADE2A",
+				"Grid": "#B877D9",
+				"Grid Usage": "#B877D9",
+				"Powerwall": "#73BF69",
+				"Powerwall Usage": "#73BF69",
+				"Solar": "#FADE2A",
+				"Solar Usage": "#FADE2A",
+				"Total Solar": "#FADE2A",
+				"Total Usage": "#5794F2"
+			},
+			"breakPoint": "50%",
+			"combine": {
+				"label": "Others",
+				"threshold": 0
+			},
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fontSize": "100%",
+			"format": "kwatth",
+			"gridPos": {
+				"h": 5,
+				"w": 8,
+				"x": 9,
+				"y": 17
+			},
+			"id": 43,
+			"interval": "",
+			"legend": {
+				"header": "Power",
+				"percentage": true,
+				"percentageDecimals": 1,
+				"show": true,
+				"sortDesc": true,
+				"values": true
+			},
+			"legendType": "Right side",
+			"links": [],
+			"maxDataPoints": 3,
+			"nullPointMode": "connected",
+			"pieType": "donut",
+			"pluginVersion": "6.5.1",
+			"strokeWidth": "1",
+			"targets": [
+				{
+					"alias": "From Solar",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"query": "SELECT  (1+from_solar/abs(from_solar))*from_solar/2  FROM (SELECT integral(solar)/1000/3600 - (integral(to_pw) - integral(grid_to_pw))/1000/3600  - integral(to_grid)/1000/3600  AS from_solar FROM (SELECT from_solar, solar, to_pw, to_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz')))",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series"
+				},
+				{
+					"alias": "From Powerwall",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT mean(\"value\") FROM \"measurement\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "From Grid",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"query": "SELECT (integral(from_grid) - integral(grid_to_pw))/1000/3600  AS from_grid FROM (SELECT from_grid, ((from_grid - home - solar) + ABS((from_grid - home - solar))) / 2 AS grid_to_pw FROM autogen.http WHERE  $timeFilter tz('$tz'))",
+					"rawQuery": true,
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "integral"
+							},
+							{
+								"params": [
+									" / 1000 / 3600"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				}
+			],
+			"title": "Self-Powered",
+			"transparent": true,
+			"type": "grafana-piechart-panel",
+			"valueName": "total"
+		},
+		{
+			"activePatternIndex": 1,
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"defaultPattern": {
+				"bgColors": "green|gray|red",
+				"bgColors_overrides": "0->green|2->red|1->yellow",
+				"clickable_cells_link": "",
+				"col_name": "Value",
+				"decimals": "2",
+				"defaultBGColor": "#5794F2",
+				"defaultTextColor": "black",
+				"delimiter": ".",
+				"displayTemplate": "_value_",
+				"enable_bgColor": false,
+				"enable_bgColor_overrides": false,
+				"enable_clickable_cells": false,
+				"enable_textColor": false,
+				"enable_textColor_overrides": false,
+				"enable_time_based_thresholds": false,
+				"enable_transform": true,
+				"enable_transform_overrides": false,
+				"filter": {
+					"value_above": "",
+					"value_below": ""
+				},
+				"format": "kwatt",
+				"name": "Default Pattern",
+				"null_color": "darkred",
+				"null_textcolor": "black",
+				"null_value": "No data",
+				"pattern": "*",
+				"row_col_wrapper": "_",
+				"row_name": "_1_",
+				"textColors": "red|orange|green",
+				"textColors_overrides": "0->red|2->green|1->yellow",
+				"thresholds": "0",
+				"time_based_thresholds": [],
+				"tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+				"transform_values": "No Usage | Using <div style=\"float: right;\">_value_</div>",
+				"transform_values_overrides": "0->down|1->up",
+				"valueName": "current"
+			},
+			"default_title_for_rows": "Metric",
+			"font_size": ".9rem",
+			"gridPos": {
+				"h": 6,
+				"w": 7,
+				"x": 17,
+				"y": 17
+			},
+			"hide_first_column": false,
+			"hide_headers": true,
+			"id": 49,
+			"interval": "",
+			"patterns": [
+				{
+					"bgColors": "#B877D9 | gray | #F2495C",
+					"bgColors_overrides": "0->green|2->red|1->yellow",
+					"clickable_cells_link": "",
+					"col_name": "Value",
+					"decimals": "2",
+					"defaultBGColor": "",
+					"defaultTextColor": "",
+					"delimiter": ".",
+					"displayTemplate": "_value_",
+					"enable_bgColor": true,
+					"enable_bgColor_overrides": false,
+					"enable_clickable_cells": false,
+					"enable_textColor": true,
+					"enable_textColor_overrides": false,
+					"enable_time_based_thresholds": false,
+					"enable_transform": true,
+					"enable_transform_overrides": false,
+					"filter": {
+						"value_above": "",
+						"value_below": ""
+					},
+					"format": "kwatt",
+					"name": "Grid",
+					"null_color": "darkred",
+					"null_textcolor": "black",
+					"null_value": "No data",
+					"pattern": "http.Grid",
+					"row_col_wrapper": "_",
+					"row_name": "_1_",
+					"textColors": "white | white | white",
+					"textColors_overrides": "0->red|2->green|1->yellow",
+					"thresholds": "-0.09,0.09",
+					"time_based_thresholds": [],
+					"tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+					"transform_values": "Exporting <div style=\"float: right;\">_value_</div> | Idle | Importing <div style=\"float: right;\">_value_</div>",
+					"transform_values_overrides": "0->down|1->up",
+					"valueName": "avg"
+				},
+				{
+					"bgColors": "#73BF69 | gray | #F2495C",
+					"bgColors_overrides": "0->green|2->red|1->yellow",
+					"clickable_cells_link": "",
+					"col_name": "Value",
+					"decimals": "2",
+					"defaultBGColor": "",
+					"defaultTextColor": "",
+					"delimiter": ".",
+					"displayTemplate": "_value_",
+					"enable_bgColor": true,
+					"enable_bgColor_overrides": false,
+					"enable_clickable_cells": false,
+					"enable_textColor": true,
+					"enable_textColor_overrides": false,
+					"enable_time_based_thresholds": false,
+					"enable_transform": true,
+					"enable_transform_overrides": false,
+					"filter": {
+						"value_above": "",
+						"value_below": ""
+					},
+					"format": "kwatt",
+					"name": "Battery",
+					"null_color": "darkred",
+					"null_textcolor": "black",
+					"null_value": "No data",
+					"pattern": "http.Battery",
+					"row_col_wrapper": "_",
+					"row_name": "_1_",
+					"textColors": "white | white | white",
+					"textColors_overrides": "0->red|2->green|1->yellow",
+					"thresholds": "-0.1,0.1",
+					"time_based_thresholds": [],
+					"tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+					"transform_values": "Charging <div style=\"float: right;\">_value_</div> | Idle | Discharging <div style=\"float: right;\">_value_</div>",
+					"transform_values_overrides": "0->down|1->up",
+					"valueName": "avg"
+				},
+				{
+					"bgColors": "red|yellow",
+					"bgColors_overrides": "0->green|2->red|1->yellow",
+					"clickable_cells_link": "",
+					"col_name": "Value",
+					"decimals": "2",
+					"defaultBGColor": "#FADE2A",
+					"defaultTextColor": "black",
+					"delimiter": ".",
+					"displayTemplate": "_value_",
+					"enable_bgColor": false,
+					"enable_bgColor_overrides": false,
+					"enable_clickable_cells": false,
+					"enable_textColor": false,
+					"enable_textColor_overrides": false,
+					"enable_time_based_thresholds": false,
+					"enable_transform": true,
+					"enable_transform_overrides": false,
+					"filter": {
+						"value_above": "",
+						"value_below": ""
+					},
+					"format": "kwatt",
+					"name": "Solar",
+					"null_color": "darkred",
+					"null_textcolor": "black",
+					"null_value": "No data",
+					"pattern": "http.Solar",
+					"row_col_wrapper": "_",
+					"row_name": "_1_",
+					"textColors": "white|black",
+					"textColors_overrides": "0->red|2->green|1->yellow",
+					"thresholds": "0.1",
+					"time_based_thresholds": [],
+					"tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+					"transform_values": "No Generation | Generating <div style=\"float: right;\">_value_</div>",
+					"transform_values_overrides": "0->down|1->up",
+					"valueName": "avg"
+				}
+			],
+			"row_col_wrapper": "_",
+			"sorting_props": {
+				"col_index": -1,
+				"direction": "desc"
+			},
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"query": "SELECT last(\"load_instant_power\")  / 1000 AS \"Home\", last(\"solar_instant_power\")  / 1000 AS \"Solar\", last(\"battery_instant_power\")  / 1000 AS \"Battery\", last(\"site_instant_power\")  / 1000 AS \"Grid\" FROM \"raw\".\"http\" WHERE time >= now() - 10m",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "time_series"
+				}
+			],
+			"title": "Current State",
+			"transparent": true,
+			"type": "yesoreyeram-boomtable-panel"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 23
+			},
+			"id": 22,
+			"panels": [],
+			"title": "Monthly Analysis",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 0,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Home Usage"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "blue",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 24
+			},
+			"id": 24,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Home Usage",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"1d"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"0"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "kwh",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"home"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "sum"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				}
+			],
+			"timeFrom": "1M",
+			"title": "Home Usage",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 0,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Solar Energy"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 24
+			},
+			"id": 25,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Solar Energy",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"1d"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"0"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "kwh",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"solar"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "sum"
+							}
+						]
+					],
+					"tags": [
+						{
+							"key": "solar",
+							"operator": ">",
+							"value": "0"
+						}
+					],
+					"tz": "$tz"
+				}
+			],
+			"timeFrom": "1M",
+			"title": "Solar Energy",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 0,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "From Powerwall"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "green",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 32
+			},
+			"id": 26,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "From Powerwall",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"1d"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"0"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "kwh",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_pw"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "sum"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				}
+			],
+			"timeFrom": "1M",
+			"title": "From Powerwall",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "bars",
+						"fillOpacity": 100,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 0,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "kwatth"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "From Grid"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "To Grid"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "purple",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "http.From Grid"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "red",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "http.To Grid"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "purple",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 32
+			},
+			"id": 27,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "From Grid",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"1d"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"0"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "kwh",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"from_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "sum"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				},
+				{
+					"alias": "To Grid",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"1d"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"0"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "kwh",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"to_grid"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "sum"
+							},
+							{
+								"params": [
+									"* -1"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": [],
+					"tz": "$tz"
+				}
+			],
+			"timeFrom": "1M",
+			"title": "Grid Usage",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"gridPos": {
+				"h": 8,
+				"w": 24,
+				"x": 0,
+				"y": 40
+			},
+			"id": 74,
+			"libraryPanel": {
+				"uid": "urTr7ciRk",
+				"name": "Solar Energy Year"
+			}
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 48
+			},
+			"id": 37,
+			"panels": [],
+			"title": "Powerwall+",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "celsius"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Solar Energy"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 6,
+				"w": 24,
+				"x": 0,
+				"y": 49
+			},
+			"id": 35,
+			"interval": "",
+			"options": {
+				"legend": {
+					"calcs": [
+						"max",
+						"min"
+					],
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Powerwall1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall4",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall5",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall6",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "F",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall7",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "G",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall8",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "H",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall9",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "I",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall10",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "J",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall11",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "K",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Powerwall12",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pwtemps",
+					"refId": "L",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_temp"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Powerwall Temps ",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "watth"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/Charge$/"
+						},
+						"properties": [
+							{
+								"id": "custom.fillOpacity",
+								"value": 10
+							},
+							{
+								"id": "custom.lineStyle",
+								"value": {
+									"dash": [
+										10,
+										10
+									],
+									"fill": "dash"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW1/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#37872D",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW2/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#E0B400",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW3/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#C4162A",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW4/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#1F60C4",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW5/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#FF9830",
+									"mode": "fixed"
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "/^PW6/"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "#8F3BB8",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 5,
+				"w": 24,
+				"x": 0,
+				"y": 55
+			},
+			"id": 55,
+			"options": {
+				"legend": {
+					"calcs": [
+						"max",
+						"min"
+					],
+					"displayMode": "table",
+					"placement": "right",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "PW1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "F",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW7_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "G",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW8_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "H",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW9_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "I",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW10_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "J",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW11_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "K",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW12_POD_nom_full_pack_energy\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "L",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_POD_nom_full_pack_energy"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW1 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "M",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "N",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "O",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "P",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "Q",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"refId": "R",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW7_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "S",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW8_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "T",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW9_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "U",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW10_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "V",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW11_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "W",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12 Charge",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "pod",
+					"query": "SELECT mean(\"PW12_POD_nom_energy_remaining\") FROM \"pod\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "X",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_POD_nom_energy_remaining"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Powerwall Capacity",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 60
+			},
+			"id": 57,
+			"panels": [],
+			"title": "Weather",
+			"type": "row"
+		},
+		{
+			"aliasColors": {
+				"Feels Like": "yellow",
+				"Temperature": "red"
+			},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 6,
+				"w": 24,
+				"x": 0,
+				"y": 61
+			},
+			"hiddenSeries": false,
+			"hideTimeOverride": false,
+			"id": 59,
+			"interval": "",
+			"legend": {
+				"avg": false,
+				"current": true,
+				"hideEmpty": false,
+				"hideZero": false,
+				"max": false,
+				"min": false,
+				"rightSide": false,
+				"show": true,
+				"total": false,
+				"values": true
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "connected",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "9.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [
+				{
+					"$$hashKey": "object:2548",
+					"alias": "Clouds (%)",
+					"color": "rgb(255, 255, 255)",
+					"dashes": true,
+					"yaxis": 2
+				},
+				{
+					"$$hashKey": "object:2549",
+					"alias": "Temperature",
+					"color": "#F2495C"
+				},
+				{
+					"$$hashKey": "object:2550",
+					"alias": "Humidity (%)",
+					"color": "#8AB8FF",
+					"dashLength": 9,
+					"dashes": true,
+					"yaxis": 2
+				},
+				{
+					"$$hashKey": "object:2551",
+					"alias": "Feels Like",
+					"dashLength": 5,
+					"dashes": true,
+					"fill": 0,
+					"spaceLength": 3
+				}
+			],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"alias": "Temperature",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"temperature"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Humidity (%)",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"humidity"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Clouds (%)",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"clouds"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Feels Like",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"feels_like"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"thresholds": [],
+			"timeRegions": [],
+			"title": "Temperature, Humidity and Clouds",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"mode": "time",
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"$$hashKey": "object:2592",
+					"format": "none",
+					"logBase": 1,
+					"show": true
+				},
+				{
+					"$$hashKey": "object:2593",
+					"format": "percent",
+					"logBase": 1,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false
+			}
+		},
+		{
+			"aliasColors": {},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 7,
+				"w": 24,
+				"x": 0,
+				"y": 67
+			},
+			"hiddenSeries": false,
+			"hideTimeOverride": false,
+			"id": 60,
+			"interval": "",
+			"legend": {
+				"avg": false,
+				"current": true,
+				"hideEmpty": false,
+				"hideZero": false,
+				"max": false,
+				"min": false,
+				"rightSide": false,
+				"show": true,
+				"total": false,
+				"values": true
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "connected",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "9.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [
+				{
+					"$$hashKey": "object:2792",
+					"alias": "Rain",
+					"color": "#1F60C4",
+					"fill": 1,
+					"yaxis": 1
+				},
+				{
+					"$$hashKey": "object:2793",
+					"alias": "Wind",
+					"color": "#FADE2A",
+					"yaxis": 1
+				},
+				{
+					"$$hashKey": "object:2794",
+					"alias": "Pressure",
+					"color": "#73BF69",
+					"yaxis": 2
+				},
+				{
+					"$$hashKey": "object:2795",
+					"alias": "Snow",
+					"color": "rgb(255, 255, 255)",
+					"dashLength": 4,
+					"dashes": true,
+					"fill": 1,
+					"spaceLength": 1
+				},
+				{
+					"$$hashKey": "object:2796",
+					"alias": "Visibility (K)",
+					"color": "rgba(255, 255, 255, 0.65)",
+					"dashes": true,
+					"fill": 0
+				}
+			],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"alias": "Snow",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"snow_1h"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Pressure",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"pressure"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Rain",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"rain_1h"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Visibility (K)",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"visibility"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							},
+							{
+								"params": [
+									" / 1000"
+								],
+								"type": "math"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Wind",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "weather",
+					"orderByTime": "ASC",
+					"policy": "autogen",
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"wind_speed"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"thresholds": [],
+			"timeRegions": [],
+			"title": "Wind, Pressure and Precipitation ",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"mode": "time",
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"$$hashKey": "object:2847",
+					"decimals": 1,
+					"format": "none",
+					"label": "",
+					"logBase": 1,
+					"show": true
+				},
+				{
+					"$$hashKey": "object:2848",
+					"format": "none",
+					"label": "",
+					"logBase": 1,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false
+			}
+		},
+		{
+			"collapsed": false,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 74
+			},
+			"id": 65,
+			"panels": [],
+			"title": "Alerts",
+			"type": "row"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "volt"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Solar Energy"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 5,
+				"w": 24,
+				"x": 0,
+				"y": 75
+			},
+			"id": 61,
+			"interval": "",
+			"options": {
+				"legend": {
+					"calcs": [
+						"max",
+						"min"
+					],
+					"displayMode": "list",
+					"placement": "right",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Home L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"ISLAND_VL1N_Load\") FROM \"vitals\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL1N_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Home L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL2N_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Home L3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": true,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"ISLAND_VL3N_Load\") FROM \"vitals\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL3N_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"METER_X_VL1N\") FROM \"vitals\".\"http\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL1N_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL2N_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": true,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"METER_X_VL3N\") FROM \"vitals\".\"http\" WHERE \"METER_X_VL3N\" > 0 AND $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": false,
+					"refId": "F",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_VL3N_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW1 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW1_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "G",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW1 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW1_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "H",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW2_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "I",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW2_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "J",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW3_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "K",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW3_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "L",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW4_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "M",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW4_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "N",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW5_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "O",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW5_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "P",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW6_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "Q",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW6_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "R",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW7_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "S",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW7_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "T",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW8_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "U",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW8_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "V",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW9_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "W",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW9_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "X",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW10_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "Y",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW10_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "Z",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW11_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AA",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW11_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AB",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12 L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW12_PINV_VSplit1\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AC",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12 L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW12_PINV_VSplit2\") FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" < 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AD",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_PINV_VSplit2"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW1_PINV_VSplit1\") +  mean(\"PW1_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AE",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW2_PINV_VSplit1\") +  mean(\"PW2_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AF",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW3_PINV_VSplit1\") +  mean(\"PW3_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AG",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW4_PINV_VSplit1\") +  mean(\"PW4_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AH",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW5_PINV_VSplit1\") +  mean(\"PW5_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AI",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW6_PINV_VSplit1\") +  mean(\"PW6_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AJ",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW7_PINV_VSplit1\") +  mean(\"PW7_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AK",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW8_PINV_VSplit1\") +  mean(\"PW8_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AL",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW9_PINV_VSplit1\") +  mean(\"PW9_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AM",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW10_PINV_VSplit1\") +  mean(\"PW10_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AN",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW11_PINV_VSplit1\") +  mean(\"PW11_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AO",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"query": "SELECT mean(\"PW12_PINV_VSplit1\") +  mean(\"PW12_PINV_VSplit2\")  FROM \"vitals\".\"http\" WHERE \"ISLAND_VL1N_Load\" > 200.0 AND  $timeFilter GROUP BY time($__interval) fill(null)",
+					"rawQuery": true,
+					"refId": "AP",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_PINV_VSplit1"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Voltages",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisCenteredZero": false,
+						"axisColorMode": "text",
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"links": [],
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green"
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "hertz"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "Solar Energy"
+						},
+						"properties": [
+							{
+								"id": "color",
+								"value": {
+									"fixedColor": "yellow",
+									"mode": "fixed"
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 5,
+				"w": 24,
+				"x": 0,
+				"y": 80
+			},
+			"id": 38,
+			"interval": "",
+			"options": {
+				"legend": {
+					"calcs": [
+						"max",
+						"min"
+					],
+					"displayMode": "list",
+					"placement": "right",
+					"showLegend": true
+				},
+				"tooltip": {
+					"mode": "multi",
+					"sort": "none"
+				}
+			},
+			"pluginVersion": "9.1.2",
+			"targets": [
+				{
+					"alias": "Home L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "A",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL1_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Home L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "B",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL2_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Home L3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": true,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "C",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL3_Load"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "D",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL1_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "E",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL2_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "Grid L3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": true,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "F",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"ISLAND_FreqL3_Main"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW1",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "G",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW1_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW2",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "H",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW2_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW3",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "I",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW3_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW4",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "J",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW4_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW5",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "K",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW5_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW6",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "L",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW6_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW7",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "M",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW7_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW8",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "N",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW8_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW9",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "O",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW9_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW10",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "P",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW10_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW11",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "Q",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW11_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				},
+				{
+					"alias": "PW12",
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"groupBy": [
+						{
+							"params": [
+								"$__interval"
+							],
+							"type": "time"
+						},
+						{
+							"params": [
+								"null"
+							],
+							"type": "fill"
+						}
+					],
+					"hide": false,
+					"measurement": "http",
+					"orderByTime": "ASC",
+					"policy": "vitals",
+					"refId": "R",
+					"resultFormat": "time_series",
+					"select": [
+						[
+							{
+								"params": [
+									"PW12_PINV_Fout"
+								],
+								"type": "field"
+							},
+							{
+								"params": [],
+								"type": "mean"
+							}
+						]
+					],
+					"tags": []
+				}
+			],
+			"title": "Frequency",
+			"transparent": true,
+			"type": "timeseries"
+		},
+		{
+			"datasource": {
+				"type": "influxdb",
+				"uid": "${DS_INFLUXDB}"
+			},
+			"description": "",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"fixedColor": "dark-blue",
+						"mode": "thresholds"
+					},
+					"custom": {
+						"fillOpacity": 41,
+						"lineWidth": 6,
+						"spanNulls": false
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "transparent"
+							},
+							{
+								"color": "blue",
+								"value": 1
+							}
+						]
+					},
+					"unit": "none"
+				},
+				"overrides": [
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "max_FWUpdateSucceeded"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "dark-green"
+										}
+									]
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "max_SystemConnectedToGrid"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "purple"
+										}
+									]
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "max_GridCodesWrite"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "dark-blue"
+										}
+									]
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "max_PodCommissionTime"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "dark-blue"
+										}
+									]
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byName",
+							"options": "max_ScheduledIslandContactorOpen"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "dark-purple"
+										}
+									]
+								}
+							}
+						]
+					},
+					{
+						"matcher": {
+							"id": "byRegexp",
+							"options": "max_PVS.*MciString.*"
+						},
+						"properties": [
+							{
+								"id": "thresholds",
+								"value": {
+									"mode": "absolute",
+									"steps": [
+										{
+											"color": "dark-blue"
+										}
+									]
+								}
+							}
+						]
+					}
+				]
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 24,
+				"x": 0,
+				"y": 85
+			},
+			"id": 68,
+			"options": {
+				"alignValue": "left",
+				"legend": {
+					"displayMode": "list",
+					"placement": "bottom",
+					"showLegend": false
+				},
+				"mergeValues": true,
+				"rowHeight": 0.51,
+				"showValue": "never",
+				"tooltip": {
+					"mode": "single",
+					"sort": "none"
+				}
+			},
+			"targets": [
+				{
+					"datasource": {
+						"type": "influxdb",
+						"uid": "${DS_INFLUXDB}"
+					},
+					"hide": false,
+					"query": "SELECT *::field from alerts.alerts where $timeFilter",
+					"rawQuery": true,
+					"refId": "A",
+					"resultFormat": "table"
+				}
+			],
+			"title": "Alerts",
+			"transformations": [
+				{
+					"id": "renameByRegex",
+					"options": {
+						"regex": "max_(.*)",
+						"renamePattern": "$1"
+					}
+				}
+			],
+			"transparent": true,
+			"type": "state-timeline"
+		}
+	],
+	"refresh": "5m",
+	"schemaVersion": 37,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"description": "Average Buy Cost Per kWh",
+				"hide": 2,
+				"label": "Buy Cost per kWh",
+				"name": "avg_buy_per_kwh",
+				"query": "${VAR_AVG_BUY_PER_KWH}",
+				"skipUrlSync": false,
+				"type": "constant",
+				"current": {
+					"value": "${VAR_AVG_BUY_PER_KWH}",
+					"text": "${VAR_AVG_BUY_PER_KWH}",
+					"selected": false
+				},
+				"options": [
+					{
+						"value": "${VAR_AVG_BUY_PER_KWH}",
+						"text": "${VAR_AVG_BUY_PER_KWH}",
+						"selected": false
+					}
+				]
+			},
+			{
+				"description": "Average Sell Cost Per kWh",
+				"hide": 2,
+				"label": "Sell Cost per kWh",
+				"name": "avg_sell_per_kwh",
+				"query": "${VAR_AVG_SELL_PER_KWH}",
+				"skipUrlSync": false,
+				"type": "constant",
+				"current": {
+					"value": "${VAR_AVG_SELL_PER_KWH}",
+					"text": "${VAR_AVG_SELL_PER_KWH}",
+					"selected": false
+				},
+				"options": [
+					{
+						"value": "${VAR_AVG_SELL_PER_KWH}",
+						"text": "${VAR_AVG_SELL_PER_KWH}",
+						"selected": false
+					}
+				]
+			},
+			{
+				"description": "Timezone",
+				"hide": 2,
+				"label": "Timezone",
+				"name": "tz",
+				"query": "${VAR_TZ}",
+				"skipUrlSync": false,
+				"type": "constant",
+				"current": {
+					"value": "${VAR_TZ}",
+					"text": "${VAR_TZ}",
+					"selected": false
+				},
+				"options": [
+					{
+						"value": "${VAR_TZ}",
+						"text": "${VAR_TZ}",
+						"selected": false
+					}
+				]
+			}
+		]
+	},
+	"time": {
+		"from": "now-24h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": [
+			"5s",
+			"10s",
+			"30s",
+			"1m",
+			"2m",
+			"5m",
+			"15m",
+			"30m",
+			"1h",
+			"2h",
+			"1d"
+		]
+	},
+	"timezone": "browser",
+	"title": "Powerwall",
+	"uid": "RSabAvRRzV",
+	"version": 14,
+	"weekStart": "sunday"
+}


### PR DESCRIPTION
I was able to update all panels except `savings` and `wind, pressure, and precip`. Thanks to @youzer-name for the solar energy year and grid status.

Disclaimer: I have no idea if this actually works on other machines