### PR TITLE
Remove option to set email sender name in pwstatus

### DIFF
--- a/tools/pwstatus/pwstatus.conf.sample
+++ b/tools/pwstatus/pwstatus.conf.sample
@@ -24,9 +24,6 @@ SHAREFILES="YES"
 # log file
 LOGFILE="/var/log/pwstatus.log"
 
-# e-mail alert sender name
-FROM="Powerwall"
-
 # e-mail alert recipient addresses
 ALERTS="alerts@example.com"
 ERRORS="errors@example.com"

--- a/tools/pwstatus/pwstatus.sh
+++ b/tools/pwstatus/pwstatus.sh
@@ -163,11 +163,6 @@ else
         NO )    chmod 644 "$COOKIE" "$GRIDSTATUS" "$VERSION" > /dev/null 2>&1;;
     esac
 
-    if [ -z "$FROM" ]
-    then
-        FROM="Powerwall"
-    fi
-
     if [ -z "$SLEEP" ] || [ $SLEEP -lt 1 ]
     then
         SLEEP=5
@@ -245,7 +240,7 @@ send_alert()
             "Message: $3" \
             "Details: $4" )"
 
-    err="$( echo -e "$body" | mail -s "$2" "$1" -F "$FROM" 2>&1 )"
+    err="$( echo -e "$body" | mail -s "$2" "$1" 2>&1 )"
     rv=$?
 
     if [ $rv -ne 0 ]
@@ -515,7 +510,6 @@ log_msg "   COOKIE     = $COOKIE"
 log_msg "   GRIDSTATUS = $GRIDSTATUS"
 log_msg "   VERSION    = $VERSION"
 log_msg "   SHAREFILES = $SHAREFILES"
-log_msg "   FROM       = $FROM"
 log_msg "   ALERTS     = $ALERTS"
 log_msg "   ERRORS     = $ERRORS"
 log_msg "   SLEEP      = $SLEEP"


### PR DESCRIPTION
Removed the option to set the e-mail sender name in the pwstatus script and config for better compatibility.

I noticed an issue when setting up a new test system, where the "-F" option of "mail" was no longer accepted to set the name of the e-mail sender (possibly due to a new version of postfix or mailx?).

I guess setting the FROM name of the sender probably should be left up to the user and their MUA/MTA/system setup instead.

The "mail" command used in the script is now generic and in the form of `mail -s "subject" [recipient-email-address]` only, which should be more generally accepted.