### PR TITLE
Update pwstatus.sh script to ignore null responses

### DIFF
--- a/tools/pwstatus/pwstatus.sh
+++ b/tools/pwstatus/pwstatus.sh
@@ -544,7 +544,11 @@ then
 else
     get_stats "api/system_status/grid_status"
     grid_status_old="$( echo "$result" | jq -sr '.[0].grid_status' )"
-    echo "$grid_status_old" > "$GRIDSTATUS"
+
+    if [ "$grid_status_old" != "null" ]
+    then
+        echo "$grid_status_old" > "$GRIDSTATUS"
+    fi
 fi
 
 if [ -s "$VERSION" ]
@@ -553,8 +557,12 @@ then
 else
     get_stats "api/status"
     version_old="$( echo "$result" | jq -sr '.[0].version' )"
-    echo "$version_old" > "$VERSION"
-    chkvernow=0
+
+    if [ "$version_old" != "null" ]
+    then
+        echo "$version_old" > "$VERSION"
+        chkvernow=0
+    fi
 fi
 
 
@@ -581,7 +589,10 @@ do
         version="$( echo "$result" | jq -sr '.[2].version' )"
         uptime="$( echo "$result" | jq -sr '.[2].up_time_seconds' )"
 
-        if [ "$version" != "$version_old" ]
+        if [ "$version" = "null" ]
+        then
+            chkvernow=1
+        elif [ "$version" != "$version_old" ]
         then
             log_msg "Firmware version changed from $version_old to $version"
 


### PR DESCRIPTION
Minor update to the Powerwall Status Monitor tool to ignore null responses, which can occur during firmware updates - refer [#109](https://github.com/jasonacox/Powerwall-Dashboard/discussions/109#discussioncomment-6193560)

This fix should ensure the correct firmware version is always returned in the e-mail alerts when a firmware update has been detected.