### PR TITLE
Shared crosshair

### DIFF
--- a/dashboards/dashboard.json
+++ b/dashboards/dashboard.json
@@ -125,7 +125,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": null,
   "links": [],
   "liveNow": false,


### PR DESCRIPTION
![Screen Recording 2023-08-25 at 12 54 05 pm](https://github.com/jasonacox/Powerwall-Dashboard/assets/484912/d7c0fb92-5c87-479d-b1d3-635767ef4b9a)

I think it's useful to be able to see the correlation of different values on the different graphs at the same time.

Grafana has an [option](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/) for "shared crosshair" which can show a crosshair on other timeline graphs when you hover over one

<img width="855" alt="image" src="https://github.com/jasonacox/Powerwall-Dashboard/assets/484912/35256057-7300-4de1-9885-02b8d025b371">

