### PR TITLE
Update tesla-history with retry handling on errors

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ echo "-----------------------------------------"
 if [ "$EUID" -eq 0 ]; then 
   echo "ERROR: Running this as root will cause permission issues."
   echo ""
-  echo "Please ensure your local user in in the docker group and run without sudo."
+  echo "Please ensure your local user is in the docker group and run without sudo."
   echo "   sudo usermod -aG docker \$USER"
   echo "   $0"
   echo ""

--- a/tools/solar-only/compose.env.sample
+++ b/tools/solar-only/compose.env.sample
@@ -19,6 +19,9 @@ GRAFANAUSER="1000:1000"
 # Accepts a colon-separated string to set the host IP, host port, and
 # container port in the form [[IP:]HOST_PORT:]CONTAINER_PORT[/PROTOCOL]
 #
+# Use 127.0.0.1 (or ::1 for IPV6) to prevent services from being exposed
+# outside of your local machine - e.g. INFLUXDB_PORTS="127.0.0.1:8086:8086"
+#
 #INFLUXDB_PORTS="8086:8086"
 #GRAFANA_PORTS="9000:9000"
 #WEATHER411_PORTS="8676:8676"

--- a/tools/solar-only/compose.env.sample
+++ b/tools/solar-only/compose.env.sample
@@ -4,3 +4,21 @@
 # See issue #22,
 # https://github.com/jasonacox/Powerwall-Dashboard/issues/22#issuecomment-1253076441
 GRAFANAUSER="1000:1000"
+
+#------------------------------------------------------------------------------#
+# Powerwall-Dashboard user and group (uid:gid)
+#------------------------------------------------------------------------------#
+# User and group dashboard was installed under and containers will run as
+# (uncomment and modify if permission issues occur due to non-default uid/gid).
+#
+#PWD_USER="1000:1000"
+
+#------------------------------------------------------------------------------#
+# Container ports to use (uncomment and modify only if custom ports required)
+#------------------------------------------------------------------------------#
+# Accepts a colon-separated string to set the host IP, host port, and
+# container port in the form [[IP:]HOST_PORT:]CONTAINER_PORT[/PROTOCOL]
+#
+#INFLUXDB_PORTS="8086:8086"
+#GRAFANA_PORTS="9000:9000"
+#WEATHER411_PORTS="8676:8676"

--- a/tools/solar-only/powerwall.yml
+++ b/tools/solar-only/powerwall.yml
@@ -5,7 +5,7 @@ services:
         image: influxdb:1.8
         container_name: influxdb
         hostname: influxdb
-        restart: always
+        restart: unless-stopped
         volumes:
             - type: bind
               source: ./influxdb.conf
@@ -15,55 +15,49 @@ services:
               source: ./influxdb
               target: /var/lib/influxdb
         ports:
-            - target: 8086
-              published: 8086
-              mode: host
+            - "${INFLUXDB_PORTS:-8086:8086}"
 
     grafana:
         image: grafana/grafana:9.1.2-ubuntu
         container_name: grafana
         hostname: grafana
-        restart: always
-        user: "${GRAFANAUSER}"
+        restart: unless-stopped
+        user: "${GRAFANAUSER:-1000:1000}"
         volumes:
             - type: bind
               source: ./grafana
               target: /var/lib/grafana
         ports:
-            - target: 9000
-              published: 9000
-              mode: host
+            - "${GRAFANA_PORTS:-9000:9000}"
         env_file:
             - grafana.env
         depends_on:
             - influxdb
 
     weather411:
-        image: jasonacox/weather411:0.2.1
+        image: jasonacox/weather411:0.2.2
         container_name: weather411
         hostname: weather411
-        restart: always
-        user: "1000:1000"
+        restart: unless-stopped
+        user: "${PWD_USER:-1000:1000}"
         volumes:
             - type: bind
               source: ./weather
               target: /var/lib/weather
               read_only: true
         ports:
-            - target: 8676
-              published: 8676
-              mode: host
+            - "${WEATHER411_PORTS:-8676:8676}"
         environment:
             - WEATHERCONF=/var/lib/weather/weather411.conf
         depends_on:
             - influxdb
 
     tesla-history:
-        image: jasonacox/tesla-history:0.1.2
+        image: jasonacox/tesla-history:0.1.3
         container_name: tesla-history
         hostname: tesla-history
-        restart: always
-        user: "1000:1000"
+        restart: unless-stopped
+        user: "${PWD_USER:-1000:1000}"
         volumes:
             - type: bind
               source: ./tesla-history

--- a/tools/solar-only/setup.sh
+++ b/tools/solar-only/setup.sh
@@ -20,7 +20,7 @@ echo "-----------------------------------------"
 if [ "$EUID" -eq 0 ]; then
   echo "ERROR: Running this as root will cause permission issues."
   echo ""
-  echo "Please ensure your local user in in the docker group and run without sudo."
+  echo "Please ensure your local user is in the docker group and run without sudo."
   echo "   sudo usermod -aG docker \$USER"
   echo "   $0"
   echo ""
@@ -144,16 +144,14 @@ fi
 echo "Setup tesla-history..."
 if type winpty > /dev/null 2>&1; then
     # Windows special case
-    winpty docker exec -it -w /var/lib/tesla-history tesla-history python3 tesla-history.py --setup --timezone "${TZ}"
+    winpty docker exec -it tesla-history python3 tesla-history.py --setup --timezone "${TZ}"
 else
-    docker exec -it -w /var/lib/tesla-history tesla-history python3 tesla-history.py --setup --timezone "${TZ}"
+    docker exec -it tesla-history python3 tesla-history.py --setup --timezone "${TZ}"
 fi
 
 # Restart tesla-history
-if [ -f tesla-history/tesla-history.conf ] && [ -f tesla-history/tesla-history.auth ]; then
-    echo "Restarting tesla-history..."
-    docker restart tesla-history
-fi
+echo "Restarting tesla-history..."
+docker restart tesla-history
 
 # Display Final Instructions
 cat << EOF

--- a/tools/solar-only/tesla-history/Dockerfile
+++ b/tools/solar-only/tesla-history/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-alpine
 WORKDIR /app
-RUN pip3 install python-dateutil teslapy influxdb
+RUN apk add build-base \
+  && pip install python-dateutil teslapy influxdb \
+  && apk del build-base
 COPY tesla-history.py tesla-history.py
 CMD ["python3", "tesla-history.py", "--daemon"]

--- a/tools/solar-only/weather.sh
+++ b/tools/solar-only/weather.sh
@@ -11,7 +11,7 @@ CONF_SRC="weather/weather411.conf.sample"
 if [ "$EUID" -eq 0 ]; then 
   echo "ERROR: Running this as root will cause permission issues."
   echo ""
-  echo "Please ensure your local user in in the docker group and run without sudo."
+  echo "Please ensure your local user is in the docker group and run without sudo."
   echo "   sudo usermod -aG docker \$USER"
   echo "   $0"
   echo ""

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -16,7 +16,7 @@ fi
 if [ "$EUID" -eq 0 ]; then
   echo "ERROR: Running this as root will cause permission issues."
   echo ""
-  echo "Please ensure your local user in in the docker group and run without sudo."
+  echo "Please ensure your local user is in the docker group and run without sudo."
   echo "   sudo usermod -aG docker \$USER"
   echo "   $0"
   echo ""

--- a/weather.sh
+++ b/weather.sh
@@ -11,7 +11,7 @@ CONF_SRC="weather/weather411.conf.sample"
 if [ "$EUID" -eq 0 ]; then 
   echo "ERROR: Running this as root will cause permission issues."
   echo ""
-  echo "Please ensure your local user in in the docker group and run without sudo."
+  echo "Please ensure your local user is in the docker group and run without sudo."
   echo "   sudo usermod -aG docker \$USER"
   echo "   $0"
   echo ""


### PR DESCRIPTION
Hi Jason,

This PR includes various updates for the Tesla-History script and Docker Compose environment. Currently for the [Solar-Only Dashboard](https://github.com/jasonacox/Powerwall-Dashboard/issues/183) #183 but with plans to migrate into the main project all going well.

I have not committed my own changes or merged this PR as the new tesla-history script will need to be pushed to the Docker Hub account please when you can.

Updates and improvements to tesla-history script:

- add retry handling on errors, which should resolve issues noted by @youzer-name in #356 
- add signal handler to exit gracefully on SIGTERM, similar to #353 noted by @rcasta74 
- always set config/variables from environment if defined (instead of just when in daemon mode)
- the "--remove" option no longer requires login to Tesla account to be used
- update setup script to always restart tesla-history container, since existing config could be modified when re-running setup
- change to `Dockerfile` to fix issue with missing build dependencies (i.e. gcc) when building & pushing container to Docker Hub

Docker Compose config changes:

- Update `powerwall.yml` to use variables for "user" and "ports" in containers, per #357 and #360 noted by @hulkster
- Updated `compose.env.sample` with explanation of latest supported options
- Proposing change to `powerwall.yml` to use "unless-stopped" as the default restart policy for containers going forward (testing/research shows this may be a better choice, happy to discuss/explain my reasoning)

@jasonacox - Please push the latest tesla-history script to Docker Hub by running `upload.sh`

Please note, I struck some issues while testing this in my dev environment.

First issue - my docker buildx environment no longer worked for some reason (something broken with latest buildx failing with cgroup errors). 

I found a workaround which was to install a different buildx driver, as below:

```bash
# Install fixed buildx instance using rootless driver image
docker buildx create --name fixed_builder --driver-opt 'image=moby/buildkit:v0.12.1-rootless' --bootstrap --use
```

I'm not sure if you will need to do the same for your environment.

Second issue - note the "RUN" command in `Dockerfile` has been been updated.

The build was failing due a dependency requiring gcc to be built. I found a nice solution which was to install alpine linux's "build-base" package (includes gcc) before running "pip install", and then it deletes the package afterwards, which keeps the container size small. Works a charm.

Please note this PR is the first with some more to come. I am working on merging the entire solar-only offshoot into the main project.

I have some preliminary changes in the works, with a more modular approach to how we handle the required docker containers, which will be determined during the setup/install process based on the user choosing a configuration option (default or solar-only).

The containers which will be installed/run are then defined by using the profiles feature of Docker Compose. Testing so far looks promising, but this is still a work in progress at the moment.