### PR TITLE
Force .env files to have LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 # Handle common extensions
 Dockerfile        text
 *.conf            text
-*.env             text
+*.env             text    eol=lf
 *.flux            text
 *.html            text    diff=html
 *.json            text


### PR DESCRIPTION
I was testing installing Powerwall-dashboard onto a new Windows environment using WSL2 shell.

I noticed that running `./setup.sh` I would hit an error after answering the question about weather

```
Weather Data Setup
-----------------------------------------
Weather data from OpenWeatherMap can be added to your Powerwall Dashboard
graphs.  This requires that you set up a free account with OpenWeatherMap
and enter the API Key during this setup process.

Do you wish to setup Weather Data? [y/N] n
No problem. If you change your mind, run weather.sh to setup later.

compose.env: line 13: $'\r': command not found
```

After a lot of trial and error I narrowed the problem down to `./compose-dash.sh up -d`

```
$ ./compose-dash.sh up -d
compose.env: line 13: $'\r': command not found
```

Then with `set -x` I narrowed it down to this line https://github.com/jasonacox/Powerwall-Dashboard/blob/10ae4588be0b0963cf1e6068fe12407e0cab705a/compose-dash.sh#L46-L47
```
+ '[' '!' -f compose.env ']'
+ set -a
+ . compose.env
++ $'\r'
compose.env: line 13: $'\r': command not found
```

Turns out [when `./setup.sh` copied](https://github.com/jasonacox/Powerwall-Dashboard/blob/214cd24a10777cfc865032b6a5716919339b8c7b/setup.sh#L209-L212) the `compose.env.sample` to `compose.env`, the file was copied with CRLF line endings (because Git saved the file with CRLF on Windows). This then broke when loading all the values from `compose.env`.

Setting `.gitattributes` to force `.env` files to have `LF` line ending seems to fix the problem.