### PR TITLE
docs: Update Cloud mode docs for HTTP/2 fix + new token auth process

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,16 @@ For Powerwall 3 owners who have their dashboard host connected to the same wired
 
 For Tesla Solar or Powerwall 3 owners without TEDAPI access, select `option 2` (Tesla Owners unofficial Cloud API) or `option 3` (Tesla official FleetAPI) and the dashboard will be installed to pull data from the Tesla Cloud API. This mode should work for ALL systems but will have slightly less details and fidelity than the "Local Access" mode.
 
-**SSH/Headless users**: Tesla Cloud setup requires a browser-based login to obtain auth tokens. If you are running setup over SSH, first run the following on a local machine (laptop/workstation) that has a browser available, then paste both the refresh token and access token when prompted:
+> **Note:** As of June 2026, Tesla requires HTTP/2 for Owner API authentication. Cloud mode (Option 2) requires **Powerwall-Dashboard v5.0.10 or later** (which includes pypowerwall `0.15.12t93` with HTTP/2 support). If you are running an older version, run `./upgrade.sh` first.
+
+**SSH/Headless users**: Tesla Cloud setup (Option 2) requires both an **Access Token** and a **Refresh Token** obtained via a browser-based Tesla login. If you are running setup over SSH, first run the following on a local machine (laptop/workstation) that has a browser available, then paste both tokens when prompted during setup:
 
 ```bash
 pip install pypowerwall -U
 python3 -m pypowerwall authtoken
 ```
+
+This will open a browser window for Tesla account login and display both tokens to copy. Alternative: use the [tesla_auth](https://github.com/adriankumpf/tesla_auth) desktop app (Windows/macOS/Linux) to generate tokens.
 
 ### Timezone
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,25 @@
 # RELEASE NOTES
 
+## v5.0.10 - Cloud Mode Fix (Token + HTTP/2)
+
+### pyPowerwall Update
+
+* Update pypowerwall Docker image to `0.15.12t93` (proxy t93).
+  - Fixes Tesla Owner API Cloud mode authentication by adding HTTP/2 support for all Tesla auth and API endpoints.
+  - Resolves the `401`/`403` errors that affected Cloud mode (Option 2) users since Tesla's June 2026 protocol change requiring HTTP/2.
+  - Adds improved token handling for SSH/headless setups — both Access Token and Refresh Token are now required during setup.
+  - See [pypowerwall PR #333](https://github.com/jasonacox/pypowerwall/pull/333) for details on the token input fix.
+
+### tesla-history Update
+
+* Update tesla-history to v0.1.8 — includes compatibility fixes for the new auth flow.
+
+### Documentation
+
+* Updated README.md Cloud mode section to document the new token-based auth process (Access Token + Refresh Token required).
+* Added note about the HTTP/2 requirement and minimum version (v5.0.10).
+* Added reference to the [tesla_auth](https://github.com/adriankumpf/tesla_auth) desktop app as an alternative token generation method for headless users.
+
 ## v5.0.9 - Tesla Owner API HTTP/2 Fix
 
 ### pyPowerwall Update


### PR DESCRIPTION
## Summary

Updates documentation to reflect that Cloud mode (Option 2) is working again as of v5.0.10, with the new authentication process.

## Changes

### README.md
- Added note about HTTP/2 requirement and minimum version (v5.0.10+)
- Documented that Cloud mode setup now requires both **Access Token** and **Refresh Token**
- Added [tesla_auth](https://github.com/adriankumpf/tesla_auth) desktop app as an alternative token generation method for headless users

### RELEASE.md
- Added v5.0.10 release notes covering:
  - pypowerwall `0.15.12t93` with HTTP/2 auth fix
  - tesla-history v0.1.8 compatibility fixes
  - Documentation updates

## Context

Addresses community feedback from #779 — Cloud mode is confirmed working with the HTTP/2 fix, but users need clear documentation about the new token-based setup process (both AT and RT required).

Ref: #779

— Sam 🌊