### PR TITLE
Clarify v1r password prompt — it is the PW3 sticker, not Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _Note: This mode also works for Powerwall 2/+ systems. Unlike TEDAPI hybrid mode
 For Powerwall 3 owners who have their dashboard host connected to the same wired network as the Powerwall 3 leader's ethernet port, select `option 5` (Wired LAN / v1r). This mode uses RSA-4096 key authentication over ethernet and does not require WiFi connectivity to `192.168.91.1`.
 
 * The Powerwall 3 leader's ethernet port must be on a routable subnet (typically `10.42.1.x/24`).
-* Setup will prompt for the full 10-character QR code gateway password (not the shorter local API password).
+* Setup will prompt for the full 10-character password from the QR sticker on your Powerwall 3 unit (not the shorter 5-character local API password). This is the same password used for TEDAPI mode — see [Powerwall 3](#powerwall-3) notes below.
 * Setup will run `pypowerwall setup -v1r` inside the container to generate and register an RSA key pair with the Powerwall via the Tesla Owner API.
 * Optionally, if your host can also reach `192.168.91.1` via WiFi, provide that as the `PW_WIFI_HOST` to enable hybrid fallback mode for follower Powerwall data and improved data completeness.
 

--- a/setup.sh
+++ b/setup.sh
@@ -439,11 +439,12 @@ if [ $v1r -eq 1 ]; then
         # Upsert PW_GW_PWD
         if ! grep -qE "^PW_GW_PWD=.+" "${PW_ENV_FILE}"; then
             echo ""
-            echo "The full 10-character gateway password is required for v1r mode."
-            echo "This is the complete QR code password on the Powerwall sticker."
+            echo "The full 10-character password from your Powerwall 3 QR sticker is required."
+            echo "This is NOT the shorter 5-character local API password."
+            echo "It is the same password used for TEDAPI mode — the one on the PW3 unit itself."
             echo ""
             while [ -z "${PW_GW_PWD}" ]; do
-                read -p 'Full 10-character Gateway Password: ' PW_GW_PWD
+                read -p 'Powerwall 3 Password (10 characters): ' PW_GW_PWD
             done
             if grep -q "^PW_GW_PWD=" "${PW_ENV_FILE}"; then
                 sed -i.bak "s|^PW_GW_PWD=.*|PW_GW_PWD=${PW_GW_PWD}|g" "${PW_ENV_FILE}"


### PR DESCRIPTION
## What

The v1r setup prompt and README used the word "gateway" when asking for the Powerwall password. For PW3 owners who also have a separate Gateway 2 unit, this created ambiguity about which sticker to read from.

## Changes

- **README.md** — v1r Mode section: clarified that the password comes from the QR sticker on the Powerwall 3 unit specifically, and noted it is the same password used for TEDAPI mode.
- **setup.sh** — v1r password prompt: replaced "Gateway Password" wording with explicit "Powerwall 3 Password" and added a line distinguishing it from the shorter 5-character local API password.

## Context

Discussion #784 — @michalperth flagged the confusion between "gateway password" (README) and "password on the Powerwall sticker" (setup prompt). This PR makes both consistent with the existing TEDAPI documentation, which already says: _"the password you find on the Powerwall 3 itself, not the one on the Gateway."_

No functional changes — documentation and prompt text only.