### PR TITLE
ci: add project validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,12 +29,19 @@ jobs:
           sudo apt-get install --no-install-recommends --yes shellcheck
 
       - name: Check Bash syntax
-        run: git ls-files -z '*.sh' | xargs -0 -n1 bash -n
+        shell: bash
+        run: |
+          while IFS= read -r -d '' file; do
+            bash -n "$file"
+          done < <(git ls-files -z '*.sh' '*.sh.sample')
 
       - name: Run ShellCheck
+        shell: bash
         run: |
           # These rules flag existing argument-forwarding patterns. Keep all other error-level checks enabled.
-          git ls-files -z '*.sh' | xargs -0 shellcheck --shell=bash --severity=error --exclude=SC2068,SC2145
+          while IFS= read -r -d '' file; do
+            shellcheck --shell=bash --severity=error --exclude=SC2068,SC2145 "$file"
+          done < <(git ls-files -z '*.sh' '*.sh.sample')
 
   structured-data:
     name: JSON and YAML
@@ -76,3 +83,17 @@ jobs:
             echo "VERSION ($file_version) does not match upgrade.sh ($upgrade_version)"
             exit 1
           fi
+
+  whitespace:
+    name: Whitespace
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed lines
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...HEAD"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,78 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell:
+    name: Shell scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes shellcheck
+
+      - name: Check Bash syntax
+        run: git ls-files -z '*.sh' | xargs -0 -n1 bash -n
+
+      - name: Run ShellCheck
+        run: |
+          # These rules flag existing argument-forwarding patterns. Keep all other error-level checks enabled.
+          git ls-files -z '*.sh' | xargs -0 shellcheck --shell=bash --severity=error --exclude=SC2068,SC2145
+
+  structured-data:
+    name: JSON and YAML
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate JSON
+        shell: bash
+        run: |
+          while IFS= read -r -d '' file; do
+            python3 -m json.tool "$file" >/dev/null
+          done < <(git ls-files -z '*.json')
+
+      - name: Validate YAML
+        shell: bash
+        run: |
+          while IFS= read -r -d '' file; do
+            ruby -e 'require "yaml"; YAML.parse_file(ARGV.fetch(0))' "$file"
+          done < <(git ls-files -z '*.yml' '*.yaml')
+
+  release-version:
+    name: Release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check version consistency
+        shell: bash
+        run: |
+          file_version=$(tr -d '[:space:]' < VERSION)
+          upgrade_version=$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' upgrade.sh)
+
+          if [[ "$file_version" != "$upgrade_version" ]]; then
+            echo "VERSION ($file_version) does not match upgrade.sh ($upgrade_version)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- add GitHub Actions validation for pull requests, pushes to `main`, and manual runs
- check all tracked shell scripts with `bash -n` and error-level ShellCheck
- parse all tracked JSON and YAML files
- verify that `VERSION` matches the version declared in `upgrade.sh`
- use read-only repository permissions and cancel superseded runs

ShellCheck excludes `SC2068` and `SC2145` because those rules flag existing argument-forwarding patterns in `compose-dash.sh` and `tools/pwstatus/pwstatus.sh`. All other error-level checks remain enabled. These exclusions can be removed after the existing findings are addressed separately.

## Validation

- `actionlint .github/workflows/validate.yml`
- `bash -n` on all tracked shell scripts
- ShellCheck at error severity on all tracked shell scripts
- JSON parsing with `python3 -m json.tool`
- YAML parsing with Ruby/Psych
- release version consistency check
- `git diff --check`