### PR TITLE
Add --debug mode and make bc non-fatal in verify.sh

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -2,8 +2,21 @@
 #
 # Setup Verification Tool for Powerwall Dashboard
 
-# Stop on Errors
-set -e
+# Debug mode: --debug flag disables set -e and reveals hidden errors
+if [[ "$1" == "--debug" ]]; then
+    DEBUG_MODE=true
+    shift
+else
+    DEBUG_MODE=false
+fi
+
+# Stop on Errors (disabled in debug mode)
+if [[ "$DEBUG_MODE" == "true" ]]; then
+    set +e
+    set -x  # Trace every command
+else
+    set -e
+fi
 
 # Function to detect if terminal has light background
 detect_light_background() {
@@ -134,10 +147,15 @@ while [[ $# -gt 0 ]]; do
             HOST="$2"
             shift 2
             ;;
+        --debug)
+            # Already handled above, just consume the arg
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
+            echo "  --debug           Disable set -e and trace all commands (verbose)"
             echo "  --no-color        Disable colored output"
             echo "  --debug-colors    Show color detection info"
             echo "  --lightbg         Force light background colors"
@@ -395,7 +413,12 @@ if [ "$HOST" != "localhost" ] || [ "$RUNNING" = "true" ]; then
             IFS=',' read -r GRID HOME SOLAR BATTERY BATTERYLEVEL GRIDSTATUS RESERVE <<< "$METRICS"
             # Scale battery level and reserve to account for Tesla's 5% reserve
             # Actual = (Raw / 0.95) - (5 / 0.95)
-            BATTERYLEVEL_SCALED=$(echo "scale=2; ($BATTERYLEVEL / 0.95) - (5 / 0.95)" | bc 2>/dev/null)
+            if command -v bc &>/dev/null; then
+                BATTERYLEVEL_SCALED=$(echo "scale=2; ($BATTERYLEVEL / 0.95) - (5 / 0.95)" | bc 2>/dev/null) || BATTERYLEVEL_SCALED="$BATTERYLEVEL"
+            else
+                BATTERYLEVEL_SCALED="$BATTERYLEVEL"
+                echo -e "${dim}   ${alertdim}NOTE: 'bc' not installed - showing raw battery level. Install with: sudo apt install bc${normal}"
+            fi
             echo -e "${dim} - Current Power Measurements:"
             echo -e "${dim}   Grid: ${subbold}${GRID}W${dim}   Home: ${subbold}${HOME}W${dim}   Solar: ${subbold}${SOLAR}W${dim}"
             echo -e "${dim}   Battery: ${subbold}${BATTERY}W${dim}   Battery Level: ${subbold}${BATTERYLEVEL_SCALED}%${dim}   Reserve: ${subbold}${RESERVE}%${dim}"

--- a/verify.sh
+++ b/verify.sh
@@ -3,12 +3,14 @@
 # Setup Verification Tool for Powerwall Dashboard
 
 # Debug mode: --debug flag disables set -e and reveals hidden errors
-if [[ "$1" == "--debug" ]]; then
-    DEBUG_MODE=true
-    shift
-else
-    DEBUG_MODE=false
-fi
+# Check all args so --debug works in any position (not just first)
+DEBUG_MODE=false
+for arg in "$@"; do
+    if [[ "$arg" == "--debug" ]]; then
+        DEBUG_MODE=true
+        break
+    fi
+done
 
 # Stop on Errors (disabled in debug mode)
 if [[ "$DEBUG_MODE" == "true" ]]; then
@@ -414,7 +416,7 @@ if [ "$HOST" != "localhost" ] || [ "$RUNNING" = "true" ]; then
             # Scale battery level and reserve to account for Tesla's 5% reserve
             # Actual = (Raw / 0.95) - (5 / 0.95)
             if command -v bc &>/dev/null; then
-                BATTERYLEVEL_SCALED=$(echo "scale=2; ($BATTERYLEVEL / 0.95) - (5 / 0.95)" | bc 2>/dev/null) || BATTERYLEVEL_SCALED="$BATTERYLEVEL"
+                BATTERYLEVEL_SCALED=$(echo "scale=2; ($BATTERYLEVEL / 0.95) - (5 / 0.95)" | bc 2>/dev/null) || { BATTERYLEVEL_SCALED="$BATTERYLEVEL"; echo -e "${dim}   ${alertdim}NOTE: Battery level scaling failed - showing raw value.${normal}"; }
             else
                 BATTERYLEVEL_SCALED="$BATTERYLEVEL"
                 echo -e "${dim}   ${alertdim}NOTE: 'bc' not installed - showing raw battery level. Install with: sudo apt install bc${normal}"


### PR DESCRIPTION
## Summary

Fixes #827

- Adds `--debug` flag to `verify.sh` that disables `set -e` and enables `set -x` (traces every command) so users can see exactly where the script fails
- Makes the `bc` call non-fatal — if `bc` is not installed, falls back to the raw battery level with a visible warning instead of silently killing the script
- Updates `--help` output to document the new flag

## What happened

@hatchjdecho reported that `verify.sh` silently exited after the pypowerwall section. Root cause: missing `bc` command + `set -e` = silent death. The `2>/dev/null` on the `bc` pipe hid the error message.

## Test plan

- [x] `bash -n verify.sh` syntax check passes
- [x] `./verify.sh --help` shows new `--debug` option
- [x] `./verify.sh` runs normally (with `set -e`)
- [x] `./verify.sh --debug` runs with tracing and without `set -e`
- [ ] Confirm with @hatchjdecho that this version works correctly

— Sam 🌊