### PR TITLE
weather411: replace deprecated datetime.utcfromtimestamp() calls

### DIFF
--- a/weather/server.py
+++ b/weather/server.py
@@ -86,7 +86,7 @@ import configparser
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-BUILD = "0.2.3"
+BUILD = "0.2.4"
 CLI = False
 LOADED = False
 CONFIG_LOADED = False

--- a/weather/server.py
+++ b/weather/server.py
@@ -76,7 +76,7 @@ import logging
 import json
 import requests
 import resource
-from datetime import datetime
+from datetime import datetime, timezone
 import signal
 import sys
 import os
@@ -292,7 +292,9 @@ def fetchWeather():
                                     org=IORG)
                             output = [{}]
                             output[0]["measurement"] = IFIELD
-                            output[0]["time"] = datetime.utcfromtimestamp(weather["dt"])
+                            # datetime.utcfromtimestamp() is deprecated since Python 3.12;
+                            # this is its documented naive-UTC-equivalent replacement.
+                            output[0]["time"] = datetime.fromtimestamp(weather["dt"], tz=timezone.utc).replace(tzinfo=None)
                             output[0]["fields"] = {}
                             for i in weather:
                                 output[0]["fields"][i] = weather[i]
@@ -373,7 +375,7 @@ class handler(BaseHTTPRequestHandler):
             ts = time.time()
             result["local_time"] = str(datetime.fromtimestamp(ts))
             result["ts"] = ts
-            result["utc"] = str(datetime.utcfromtimestamp(ts)) 
+            result["utc"] = str(datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None))
             result["tz"] = weather["tz"]
             message = json.dumps(result)
         elif self.path == '/temp':


### PR DESCRIPTION
## Summary
- `datetime.utcfromtimestamp()` is deprecated since Python 3.12 and scheduled for removal. Replace both call sites in `weather/server.py` with the documented equivalent: `datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)`.
- Verified this produces byte-identical output to the old call for the same input timestamp — pure forward-compatibility cleanup, no behavior change.

## Context
Split out from the TimescaleDB PR (#830) per review feedback. Note this is *not* the same class of bug as the TimescaleDB write path's timestamp issue — `weather411` writes to InfluxDB via `influxdb_client`, whose `DateHelper.to_utc()` already treats naive datetimes as UTC by default, so the prior `utcfromtimestamp()` output was already being interpreted correctly on write. This PR is purely about the upcoming Python deprecation removal, not a data-correctness fix.

## Test plan
- [x] `python3 -m py_compile weather/server.py`
- [x] Confirmed `datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None) == datetime.utcfromtimestamp(ts)` for the same `ts`