### PR TITLE
Pin explicit UIDs on auto-provisioned Grafana datasources

### DIFF
--- a/grafana/provisions/datasources/influxdb.yml
+++ b/grafana/provisions/datasources/influxdb.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: InfluxDB (auto provisioned)
     type: influxdb
+    uid: pwd-influxdb-auto
     access: proxy
     url: http://influxdb:8086
     database: powerwall

--- a/grafana/sunandmoon-template.yml
+++ b/grafana/sunandmoon-template.yml
@@ -3,7 +3,8 @@ apiVersion: 1
 datasources:
   - name: Sun and Moon (auto provisioned)
     type: fetzerch-sunandmoon-datasource
-    jsonData: 
-      latitude: zzLAT 
+    uid: pwd-sunandmoon-auto
+    jsonData:
+      latitude: zzLAT
       longitude: zzLONG
     editable: true


### PR DESCRIPTION
## Summary
- Add `uid: pwd-influxdb-auto` to `grafana/provisions/datasources/influxdb.yml` and `uid: pwd-sunandmoon-auto` to `grafana/sunandmoon-template.yml`.
- Without an explicit `uid`, Grafana auto-assigns one at provisioning time. That can collide (e.g. when a second auto-provisioned Postgres-family datasource is added elsewhere in the stack) or drift across restarts/reprovisioning, breaking dashboard panels that reference a datasource by UID.

## ⚠️ Upgrade note (please read before merging)
This is a **breaking change for existing installs**: on next Grafana restart after upgrading, these datasources will get the new pinned UID if they previously had a different Grafana-generated one. Dashboards imported *before* this change may show "datasource not found" on affected panels until either:
- the dashboard is re-imported, or
- the panel's datasource is manually re-linked to the same-named datasource in the Grafana UI.

Worth a callout in the release notes for whatever version this lands in, so upgrading users aren't surprised. Happy to draft that note if useful — didn't want to presume the versioning/release process by editing `RELEASE.md`/`VERSION` myself.

## Test plan
- [x] YAML validated (`yaml.safe_load`) on both changed files
- [ ] Manual: confirm Grafana provisions both datasources with the pinned UIDs on a fresh `setup.sh` run, and that existing dashboards can be re-linked without issue