### PR TITLE
Add tools/powerwall-mcp: MCP server for AI agents to query dashboard data

### DIFF
--- a/tools/powerwall-mcp/Dockerfile
+++ b/tools/powerwall-mcp/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# uvicorn + starlette are needed for the optional bearer-auth wrapper path;
+# harmless if MCP_AUTH_TOKEN is unset.
+RUN pip install --no-cache-dir \
+    "mcp>=1.0,<2" \
+    influxdb \
+    uvicorn \
+    starlette
+
+COPY server.py .
+
+ENV MCP_HOST=0.0.0.0 \
+    MCP_PORT=8000
+
+EXPOSE 8000
+
+CMD ["python", "server.py"]

--- a/tools/powerwall-mcp/Dockerfile
+++ b/tools/powerwall-mcp/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # harmless if MCP_AUTH_TOKEN is unset.
 RUN pip install --no-cache-dir \
     "mcp>=1.0,<2" \
+    "pydantic-settings<2.15" \
     influxdb \
     uvicorn \
     starlette

--- a/tools/powerwall-mcp/README.md
+++ b/tools/powerwall-mcp/README.md
@@ -1,0 +1,47 @@
+# powerwall-mcp — MCP Server for Powerwall-Dashboard
+
+An optional, self-contained [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI agents (Claude, Open WebUI, Hermes, and other MCP-capable clients) query your Powerwall-Dashboard InfluxDB 1.8 data in plain language.
+
+Ask things like:
+
+- "What was my solar ROI last year?"
+- "Was buying a Powerwall worth it?"
+- "Is cleaning my panels worth it?" (feed it cleaning dates/costs)
+
+…all answered from *your* actual historical data.
+
+## Why a dedicated MCP server?
+
+Most existing InfluxDB MCP servers target InfluxDB 2.x/3.x, while Powerwall-Dashboard ships InfluxDB 1.8. More importantly, the Telegraf exporter writes the **same measurement names into multiple retention policies** (`autogen`, `raw`, `vitals`, `kwh`, `daily`, `grid`, `pod`, `alerts`), each holding a different slice of the data. Generic servers miss this entirely — this tool knows the schema.
+
+The server exposes tools to:
+
+- `get_database_overview` — map every retention policy and measurement (use this first)
+- `get_retention_policies` / `get_measurements` / `get_field_keys` — explore the schema
+- `query_powerwall` — run InfluxQL `SELECT` queries (read-only)
+
+## Setup
+
+```bash
+cd tools/powerwall-mcp
+```
+
+Edit `docker-compose.yml` and set `INFLUX_HOST` to the host running your Powerwall-Dashboard InfluxDB (e.g. your dashboard host's LAN IP). Leave `INFLUX_PORT` (8086) and `INFLUX_DB` (powerwall) at their defaults unless you've changed them.
+
+If the port is reachable beyond your own trusted LAN, set `MCP_AUTH_TOKEN` to a strong secret — clients must then send it as a bearer token.
+
+Build and run:
+
+```bash
+docker compose up -d --build
+```
+
+The MCP server is available at `http://<host-ip>:8765/mcp` (streamable HTTP transport). Add that URL to your MCP-capable agent/client.
+
+> Note: this runs its own compose stack, separate from the dashboard — don't use `compose-dash.sh` here.
+
+## Credit
+
+Based on the original `powerwall-dashboard-mcp` by [@ampersandru](https://github.com/ampersandru/powerwall-dashboard-mcp), contributed via [#848](https://github.com/jasonacox/Powerwall-Dashboard/issues/848). Thank you!
+
+**AI Disclaimer** (from the original author): this was AI-assisted. Use at your own risk!

--- a/tools/powerwall-mcp/README.md
+++ b/tools/powerwall-mcp/README.md
@@ -30,6 +30,12 @@ Edit `docker-compose.yml` and set `INFLUX_HOST` to the host running your Powerwa
 
 If the port is reachable beyond your own trusted LAN, set `MCP_AUTH_TOKEN` to a strong secret — clients must then send it as a bearer token.
 
+Queries must include a `LIMIT` no greater than `MAX_QUERY_ROWS` (default 1000)
+to prevent an agent from accidentally loading the full history into memory.
+`INFLUX_TIMEOUT` controls the database request timeout in seconds (default 30).
+The database overview is cached for `OVERVIEW_CACHE_TTL` seconds (default 300);
+clients can request an immediate refresh with `get_database_overview(refresh=true)`.
+
 Build and run:
 
 ```bash
@@ -39,6 +45,19 @@ docker compose up -d --build
 The MCP server is available at `http://<host-ip>:8765/mcp` (streamable HTTP transport). Add that URL to your MCP-capable agent/client.
 
 > Note: this runs its own compose stack, separate from the dashboard — don't use `compose-dash.sh` here.
+
+## Mock agent client
+
+`mock_client.py` is a dependency-free smoke client that initializes an MCP
+session, discovers the available tools and schema, runs bounded queries, and
+prints current power, battery, grid, and previous-day energy summaries:
+
+Set `--url` to the MCP server URL created by the Docker setup above. When the
+client runs on the same computer as the server, use:
+
+```bash
+python3 mock_client.py --url http://127.0.0.1:8765/mcp
+```
 
 ## Credit
 

--- a/tools/powerwall-mcp/README.md
+++ b/tools/powerwall-mcp/README.md
@@ -26,7 +26,7 @@ The server exposes tools to:
 cd tools/powerwall-mcp
 ```
 
-Edit `docker-compose.yml` and set `INFLUX_HOST` to the host running your Powerwall-Dashboard InfluxDB (e.g. your dashboard host's LAN IP). Leave `INFLUX_PORT` (8086) and `INFLUX_DB` (powerwall) at their defaults unless you've changed them.
+Edit `docker-compose.yml` and set `INFLUX_HOST` to the host running your Powerwall-Dashboard InfluxDB. The compose file defaults to `INFLUX_HOST=127.0.0.1` with `network_mode: host`, which works out of the box on **Linux** when the MCP server runs on the same host as InfluxDB. Use your dashboard host's **LAN IP** instead if InfluxDB runs on a different machine, or if you're on **Docker Desktop** (macOS/Windows), which doesn't support host networking — there, point `INFLUX_HOST` at the LAN IP of the machine running the dashboard. Leave `INFLUX_PORT` (8086) and `INFLUX_DB` (powerwall) at their defaults unless you've changed them.
 
 If the port is reachable beyond your own trusted LAN, set `MCP_AUTH_TOKEN` to a strong secret — clients must then send it as a bearer token.
 

--- a/tools/powerwall-mcp/docker-compose.yml
+++ b/tools/powerwall-mcp/docker-compose.yml
@@ -8,5 +8,8 @@ services:
       INFLUX_HOST: "127.0.0.1"
       INFLUX_PORT: "8086"
       INFLUX_DB: "powerwall"
+      INFLUX_TIMEOUT: "30"
       MCP_PORT: "8765"
       MCP_AUTH_TOKEN: ""
+      MAX_QUERY_ROWS: "1000"
+      OVERVIEW_CACHE_TTL: "300"

--- a/tools/powerwall-mcp/docker-compose.yml
+++ b/tools/powerwall-mcp/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  powerwall-mcp:
+    build: .
+    container_name: powerwall-mcp
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      INFLUX_HOST: "127.0.0.1"
+      INFLUX_PORT: "8086"
+      INFLUX_DB: "powerwall"
+      MCP_PORT: "8765"
+      MCP_AUTH_TOKEN: ""

--- a/tools/powerwall-mcp/mock_client.py
+++ b/tools/powerwall-mcp/mock_client.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Small MCP client that demonstrates an agent-style Powerwall query workflow."""
+
+import argparse
+import json
+import math
+import sys
+import urllib.error
+import urllib.request
+
+
+class MCPClient:
+    def __init__(self, url, auth_token=None):
+        self.url = url
+        self.auth_token = auth_token
+        self.session_id = None
+        self.request_id = 0
+
+    def _post(self, payload):
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+
+        request = urllib.request.Request(
+            self.url,
+            data=json.dumps(payload).encode(),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=60) as response:
+            if not self.session_id:
+                self.session_id = response.headers.get("Mcp-Session-Id")
+            body = response.read().decode()
+
+        data_lines = [
+            line.removeprefix("data:").strip()
+            for line in body.splitlines()
+            if line.startswith("data:")
+        ]
+        if not data_lines:
+            return None
+        message = json.loads("\n".join(data_lines))
+        if "error" in message:
+            error = message["error"]
+            raise RuntimeError(f"MCP error {error.get('code')}: {error.get('message')}")
+        return message.get("result")
+
+    def request(self, method, params=None):
+        self.request_id += 1
+        return self._post(
+            {
+                "jsonrpc": "2.0",
+                "id": self.request_id,
+                "method": method,
+                "params": params or {},
+            }
+        )
+
+    def notify(self, method, params=None):
+        self._post(
+            {
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params or {},
+            }
+        )
+
+    def initialize(self):
+        result = self.request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "powerwall-mcp-mock-agent",
+                    "version": "1.0",
+                },
+            },
+        )
+        self.notify("notifications/initialized")
+        return result
+
+    def call_tool(self, name, arguments=None):
+        result = self.request(
+            "tools/call",
+            {"name": name, "arguments": arguments or {}},
+        )
+        if result.get("isError"):
+            raise RuntimeError(result["content"][0]["text"])
+        value = result.get("structuredContent", {}).get("result")
+        if value is None:
+            value = result["content"][0]["text"]
+        return json.loads(value)
+
+
+def available_fields(overview, retention_policy, measurement):
+    return overview.get(retention_policy, {}).get(measurement, {}).get("fields", [])
+
+
+def query_latest(client, overview, retention_policy, measurement, desired_fields, where=""):
+    fields = [
+        field
+        for field in desired_fields
+        if field in available_fields(overview, retention_policy, measurement)
+    ]
+    if not fields:
+        return None
+    columns = ", ".join(f'"{field}"' for field in fields)
+    query = f'SELECT {columns} FROM "{retention_policy}"."{measurement}"'
+    if where:
+        query += f" WHERE {where}"
+    query += " ORDER BY time DESC LIMIT 1"
+    rows = client.call_tool("query_powerwall", {"query": query})
+    return rows[0] if rows else None
+
+
+def number(value):
+    return float(value) if isinstance(value, (int, float)) and math.isfinite(value) else 0.0
+
+
+def power_direction(imported, exported, import_label, export_label):
+    net = number(imported) - number(exported)
+    if abs(net) < 1:
+        return "idle"
+    if net > 0:
+        return f"{import_label} {net:,.0f} W"
+    return f"{export_label} {-net:,.0f} W"
+
+
+def print_report(current, pod, grid, yesterday):
+    print("\nPowerwall summary")
+    print("=================")
+
+    if current:
+        print(f"Latest sample:       {current.get('time', 'unknown')}")
+        print(f"Solar production:    {number(current.get('solar')):,.0f} W")
+        print(f"Home consumption:    {number(current.get('home')):,.0f} W")
+        print(
+            "Grid flow:          "
+            + power_direction(
+                current.get("from_grid"),
+                current.get("to_grid"),
+                "importing",
+                "exporting",
+            )
+        )
+        print(
+            "Battery flow:       "
+            + power_direction(
+                current.get("from_pw"),
+                current.get("to_pw"),
+                "supplying",
+                "charging",
+            )
+        )
+        if "percentage" in current:
+            print(f"Battery charge:      {number(current['percentage']):.1f}%")
+    else:
+        print("Current power data:  unavailable")
+
+    if pod:
+        remaining = number(pod.get("nominal_energy_remaining"))
+        capacity = number(pod.get("nominal_full_pack_energy"))
+        if remaining:
+            print(f"Stored energy:       {remaining / 1000:,.1f} kWh")
+        if capacity:
+            print(f"Pack capacity:       {capacity / 1000:,.1f} kWh")
+        if "backup_reserve_percent" in pod:
+            print(f"Backup reserve:      {number(pod['backup_reserve_percent']):.1f}%")
+
+    if grid and "grid_status" in grid:
+        print(f"Grid status:         {grid['grid_status']}")
+
+    if yesterday:
+        solar = number(yesterday.get("solar"))
+        home = number(yesterday.get("home"))
+        exported = number(yesterday.get("to_grid"))
+        imported = number(yesterday.get("from_grid"))
+        self_consumed = max(solar - exported, 0)
+        print("\nPrevious complete day")
+        print("---------------------")
+        print(f"Date bucket:         {yesterday.get('time', 'unknown')}")
+        print(f"Solar generated:     {solar:,.1f} kWh")
+        print(f"Home consumed:       {home:,.1f} kWh")
+        print(f"Grid imported:       {imported:,.1f} kWh")
+        print(f"Grid exported:       {exported:,.1f} kWh")
+        print(f"Solar self-consumed: {self_consumed:,.1f} kWh")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Exercise Powerwall MCP tools like a simple AI agent."
+    )
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8765/mcp",
+        help="Streamable HTTP MCP endpoint",
+    )
+    parser.add_argument("--auth-token", help="Optional MCP bearer token")
+    args = parser.parse_args()
+
+    client = MCPClient(args.url, args.auth_token)
+    initialized = client.initialize()
+    server = initialized.get("serverInfo", {})
+    print(f"Connected to {server.get('name', 'MCP server')} {server.get('version', '')}")
+
+    tools = client.request("tools/list").get("tools", [])
+    print("Discovered tools: " + ", ".join(tool["name"] for tool in tools))
+
+    overview = client.call_tool("get_database_overview")
+    populated = {
+        policy: sorted(measurements)
+        for policy, measurements in overview.items()
+        if measurements
+    }
+    print(
+        f"Discovered {len(populated)} populated retention policies: "
+        + ", ".join(populated)
+    )
+
+    current = query_latest(
+        client,
+        overview,
+        "autogen",
+        "http",
+        ["solar", "home", "from_grid", "to_grid", "from_pw", "to_pw", "percentage"],
+    )
+    pod = query_latest(
+        client,
+        overview,
+        "pod",
+        "http",
+        [
+            "nominal_energy_remaining",
+            "nominal_full_pack_energy",
+            "backup_reserve_percent",
+        ],
+    )
+    grid = query_latest(client, overview, "grid", "http", ["grid_status"])
+    yesterday = query_latest(
+        client,
+        overview,
+        "daily",
+        "http",
+        ["solar", "home", "from_grid", "to_grid", "from_pw", "to_pw"],
+        "time < now() - 1d",
+    )
+    print_report(current, pod, grid, yesterday)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/powerwall-mcp/server.py
+++ b/tools/powerwall-mcp/server.py
@@ -13,7 +13,10 @@ data:
   grid     (7d)           http (grid_status)
   pod      (7d)           http (battery: nominal_energy_remaining, backup_reserve_percent)
   alerts   (7d)           alerts (Powerwall alert events)
-  strings / pwtemps / monthly / fans  (created, currently empty)
+  strings  (unlimited)    solar string voltage/current/power
+  pwtemps  (unlimited)    Powerwall temperatures
+  monthly  (unlimited)    monthly energy totals
+  fans     (unlimited)    Powerwall fan target/actual speeds
 
 CRITICAL: InfluxQL `SHOW MEASUREMENTS` and unqualified `SELECT`/`SHOW FIELD KEYS`
 only ever address the DEFAULT retention policy (autogen). To read data from any
@@ -37,6 +40,7 @@ import hmac
 import json
 import os
 import re
+import time
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -45,15 +49,23 @@ from influxdb import InfluxDBClient
 INFLUX_HOST = os.environ.get("INFLUX_HOST", "127.0.0.1")
 INFLUX_PORT = int(os.environ.get("INFLUX_PORT", "8086"))
 INFLUX_DB = os.environ.get("INFLUX_DB", "powerwall")
+INFLUX_TIMEOUT = int(os.environ.get("INFLUX_TIMEOUT", "30"))
 
 MCP_HOST = os.environ.get("MCP_HOST", "0.0.0.0")
 MCP_PORT = int(os.environ.get("MCP_PORT", "8000"))
 MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN")  # optional bearer token
+MAX_QUERY_ROWS = int(os.environ.get("MAX_QUERY_ROWS", "1000"))
+OVERVIEW_CACHE_TTL = int(os.environ.get("OVERVIEW_CACHE_TTL", "300"))
 
 # Initialize the MCP Server, bound for HTTP hosting.
 mcp = FastMCP("Powerwall_Dashboard", host=MCP_HOST, port=MCP_PORT)
 
-client = InfluxDBClient(host=INFLUX_HOST, port=INFLUX_PORT, database=INFLUX_DB)
+client = InfluxDBClient(
+    host=INFLUX_HOST,
+    port=INFLUX_PORT,
+    database=INFLUX_DB,
+    timeout=INFLUX_TIMEOUT,
+)
 
 # Measurement names written by the Powerwall-Dashboard Telegraf config. Used to
 # probe each RP, because InfluxQL has no "SHOW MEASUREMENTS FROM <rp>".
@@ -64,11 +76,20 @@ _KNOWN_MEASUREMENTS = {
 
 # Cache for the expensive all-RP scan so repeated overview calls are instant.
 _OVERVIEW_CACHE = None
+_OVERVIEW_CACHE_TIME = 0.0
 
 # Identifiers we will interpolate into InfluxQL: bare word characters, dots
 # and hyphens. Anything else (quotes, semicolons, spaces, parens...) is
 # rejected so tool arguments can never break out of the quoted identifier.
 _IDENT_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$")
+_LIMIT_RE = re.compile(
+    r"\bLIMIT\s+(\d+)"
+    r"(?:\s+OFFSET\s+\d+)?"
+    r"(?:\s+SLIMIT\s+\d+)?"
+    r"(?:\s+SOFFSET\s+\d+)?"
+    r"(?:\s+TZ\s*\(\s*'[^']+'\s*\))?\s*$",
+    re.IGNORECASE,
+)
 
 
 def _safe_ident(name: str) -> bool:
@@ -114,28 +135,37 @@ def _build_overview():
             if not pts:
                 continue  # no data in this RP for this measurement
             latest = pts[0]
-            fields = [k for k in latest.keys() if k != "time" and not k.startswith("tags")]
+            field_points = client.query(
+                f'SHOW FIELD KEYS FROM "{rp}"."{m}"'
+            ).get_points()
+            fields = sorted(
+                p["fieldKey"] for p in field_points if p.get("fieldKey")
+            )
             rp_map[m] = {"latest_time": latest.get("time"), "fields": fields}
         overview[rp] = rp_map
     return overview
 
 
 def _get_overview(force=False):
-    global _OVERVIEW_CACHE
-    if _OVERVIEW_CACHE is None or force:
+    global _OVERVIEW_CACHE, _OVERVIEW_CACHE_TIME
+    now = time.monotonic()
+    cache_expired = now - _OVERVIEW_CACHE_TIME >= OVERVIEW_CACHE_TTL
+    if _OVERVIEW_CACHE is None or force or cache_expired:
         _OVERVIEW_CACHE = _build_overview()
+        _OVERVIEW_CACHE_TIME = now
     return _OVERVIEW_CACHE
 
 
 @mcp.tool()
-def get_database_overview() -> str:
+def get_database_overview(refresh: bool = False) -> str:
     """Map the WHOLE database: every retention policy and, for each, the
     measurements that actually contain data, with their latest point time and
     field names. Use this FIRST to discover what is available before querying.
+    Set refresh=true to bypass the short-lived overview cache.
     (The old get_measurements only saw the default 'autogen' RP and missed the
     real Powerwall data in raw/vitals/kwh/daily/grid/pod/alerts.)"""
     try:
-        return json.dumps(_get_overview(), indent=2, default=str)
+        return json.dumps(_get_overview(force=refresh), indent=2, default=str)
     except Exception as e:
         return f"Error: {str(e)}"
 
@@ -206,11 +236,11 @@ def query_powerwall(query: str) -> str:
       SELECT * FROM "kwh".http ORDER BY time DESC LIMIT 10
       SELECT mean("solar") FROM "autogen".http WHERE time >= now() - 1h GROUP BY time(5m)
       SELECT "solar","home","to_grid","to_pw" FROM "daily".http ORDER BY time DESC LIMIT 7
-      SELECT * FROM "pod".http ORDER BY time DESC LIMIT 1   -- battery state
-      SELECT * FROM "vitals".http ORDER BY time DESC LIMIT 1  -- inverter vitals
+      SELECT * FROM "pod".http ORDER BY time DESC LIMIT 1
+      SELECT * FROM "vitals".http ORDER BY time DESC LIMIT 1
     Available RPs: autogen, raw, vitals, kwh, daily, grid, pod, alerts
-    (strings, pwtemps, monthly, fans are empty).
-    Only SELECT statements are allowed."""
+    plus strings, pwtemps, monthly, and fans when supported by the installation.
+    Only SELECT statements with LIMIT <= MAX_QUERY_ROWS are allowed."""
     q = query.strip()
     # Allow (and strip) trailing statement terminators, as agents often emit
     # them; any remaining semicolon means multiple statements.
@@ -221,6 +251,17 @@ def query_powerwall(query: str) -> str:
         return "Error: Security exception. Multiple statements are not allowed."
     if re.search(r"\bINTO\b", q, re.IGNORECASE):
         return "Error: Security exception. SELECT ... INTO writes are not allowed."
+    if "--" in q or "/*" in q or "*/" in q:
+        return "Error: SQL comments are not allowed."
+    limit_match = _LIMIT_RE.search(q)
+    if not limit_match:
+        return (
+            "Error: Query must end with a LIMIT clause to prevent unbounded results "
+            f"(maximum {MAX_QUERY_ROWS}; OFFSET/SLIMIT/SOFFSET/TZ may follow)."
+        )
+    limit = int(limit_match.group(1))
+    if limit < 1 or limit > MAX_QUERY_ROWS:
+        return f"Error: LIMIT must be between 1 and {MAX_QUERY_ROWS}."
     try:
         result = client.query(q)
         data = list(result.get_points())

--- a/tools/powerwall-mcp/server.py
+++ b/tools/powerwall-mcp/server.py
@@ -1,0 +1,237 @@
+"""Powerwall-Dashboard InfluxDB MCP server (HTTP transport, Docker-ready).
+
+The Powerwall-Dashboard Telegraf exporter writes the SAME measurement names
+into MULTIPLE retention policies (RPs), each holding a different slice of the
+data:
+
+  autogen  (default, 7d)  http (1-min power flow: solar/home/grid/battery kW), weather
+  raw      (72h)          alerts, cpu, disk, diskio, http (80-field Powerwall status),
+                          kernel, mem, powerwall_dashboard, processes, swap, system
+  vitals   (7d)           http (inverter vitals: PW1_p_out, PW1_v_out, PW1_f_out, ...)
+  kwh      (7d)           http (hourly kWh: solar/home/to_grid/to_pw/from_grid/from_pw)
+  daily    (7d)           http (daily kWh totals)
+  grid     (7d)           http (grid_status)
+  pod      (7d)           http (battery: nominal_energy_remaining, backup_reserve_percent)
+  alerts   (7d)           alerts (Powerwall alert events)
+  strings / pwtemps / monthly / fans  (created, currently empty)
+
+CRITICAL: InfluxQL `SHOW MEASUREMENTS` and unqualified `SELECT`/`SHOW FIELD KEYS`
+only ever address the DEFAULT retention policy (autogen). To read data from any
+other RP you MUST qualify the table as  "rp".measurement  (e.g. "kwh".http).
+
+This version runs over Streamable HTTP so it can be exposed on the network and
+linked to agents via a URL (http://<host>:<port>/mcp), instead of stdio.
+Configuration is via environment variables so it can be set in docker-compose
+without editing code:
+
+  INFLUX_HOST   default: 127.0.0.1
+  INFLUX_PORT   default: 8086
+  INFLUX_DB     default: powerwall
+  MCP_HOST      default: 0.0.0.0   (bind address inside the container)
+  MCP_PORT      default: 8000
+  MCP_AUTH_TOKEN  optional bearer token; if set, requests must include
+                  Authorization: Bearer <token>
+"""
+
+import json
+import os
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+from influxdb import InfluxDBClient
+
+INFLUX_HOST = os.environ.get("INFLUX_HOST", "127.0.0.1")
+INFLUX_PORT = int(os.environ.get("INFLUX_PORT", "8086"))
+INFLUX_DB = os.environ.get("INFLUX_DB", "powerwall")
+
+MCP_HOST = os.environ.get("MCP_HOST", "0.0.0.0")
+MCP_PORT = int(os.environ.get("MCP_PORT", "8000"))
+MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN")  # optional bearer token
+
+# Initialize the MCP Server, bound for HTTP hosting.
+mcp = FastMCP("Powerwall_Dashboard", host=MCP_HOST, port=MCP_PORT)
+
+client = InfluxDBClient(host=INFLUX_HOST, port=INFLUX_PORT, database=INFLUX_DB)
+
+# Measurement names written by the Powerwall-Dashboard Telegraf config. Used to
+# probe each RP, because InfluxQL has no "SHOW MEASUREMENTS FROM <rp>".
+_KNOWN_MEASUREMENTS = {
+    "alerts", "cpu", "disk", "diskio", "http", "kernel", "mem",
+    "powerwall_dashboard", "processes", "swap", "system", "weather",
+}
+
+# Cache for the expensive all-RP scan so repeated overview calls are instant.
+_OVERVIEW_CACHE = None
+
+
+def _measurement_pool():
+    """Union of default-RP measurements and the known Powerwall measurement set."""
+    names = set(_KNOWN_MEASUREMENTS)
+    try:
+        for p in client.query("SHOW MEASUREMENTS").get_points():
+            names.add(p.get("name"))
+    except Exception:
+        pass
+    return sorted(n for n in names if n)
+
+
+def _rps():
+    """Names of all retention policies in the database."""
+    try:
+        return [p["name"] for p in client.query("SHOW RETENTION POLICIES").get_points()]
+    except Exception as e:
+        return [f"Error: {e}"]
+
+
+def _build_overview():
+    """Map every RP -> {measurement: {latest_time, fields}} for tables with data."""
+    overview = {}
+    pool = _measurement_pool()
+    for rp in _rps():
+        if not isinstance(rp, str) or rp.startswith("Error"):
+            continue
+        rp_map = {}
+        for m in pool:
+            try:
+                pts = list(
+                    client.query(
+                        f'SELECT * FROM "{rp}"."{m}" ORDER BY time DESC LIMIT 1'
+                    ).get_points()
+                )
+            except Exception:
+                continue
+            if not pts:
+                continue  # no data in this RP for this measurement
+            latest = pts[0]
+            fields = [k for k in latest.keys() if k != "time" and not k.startswith("tags")]
+            rp_map[m] = {"latest_time": latest.get("time"), "fields": fields}
+        overview[rp] = rp_map
+    return overview
+
+
+def _get_overview(force=False):
+    global _OVERVIEW_CACHE
+    if _OVERVIEW_CACHE is None or force:
+        _OVERVIEW_CACHE = _build_overview()
+    return _OVERVIEW_CACHE
+
+
+@mcp.tool()
+def get_database_overview() -> str:
+    """Map the WHOLE database: every retention policy and, for each, the
+    measurements that actually contain data, with their latest point time and
+    field names. Use this FIRST to discover what is available before querying.
+    (The old get_measurements only saw the default 'autogen' RP and missed the
+    real Powerwall data in raw/vitals/kwh/daily/grid/pod/alerts.)"""
+    try:
+        return json.dumps(_get_overview(), indent=2, default=str)
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@mcp.tool()
+def get_retention_policies() -> str:
+    """List all retention policies (RPs) with their duration. You must qualify
+    queries with an RP name to read non-default data, e.g. SELECT * FROM "kwh".http."""
+    try:
+        return json.dumps(
+            list(client.query("SHOW RETENTION POLICIES").get_points()),
+            indent=2,
+            default=str,
+        )
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@mcp.tool()
+def get_measurements(retention_policy: Optional[str] = None) -> str:
+    """List measurements that contain data.
+    - retention_policy=None (default): returns EVERY RP -> [measurements with data].
+    - retention_policy='kwh' (etc.): returns just that RP's [measurements with data].
+    Note: unqualified InfluxQL only sees the default RP ('autogen'), so always
+    pass the RP you care about when you know it."""
+    try:
+        overview = _get_overview()
+        if retention_policy is None:
+            return json.dumps(
+                {rp: sorted(meas.keys()) for rp, meas in overview.items()},
+                indent=2,
+            )
+        meas = overview.get(retention_policy, {})
+        return json.dumps(
+            {"retention_policy": retention_policy, "measurements": sorted(meas.keys())},
+            indent=2,
+        )
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@mcp.tool()
+def get_field_keys(measurement: str, retention_policy: str = "autogen") -> str:
+    """Get the field (column) names for a measurement in a SPECIFIC retention
+    policy. retention_policy defaults to 'autogen' — pass e.g. 'raw' or 'kwh'
+    to inspect those RPs. Returns [] if that RP has no data for the measurement.
+    Useful fields: raw.http has the full 80-field Powerwall status; kwh.http and
+    daily.http have solar/home/to_grid/to_pw/from_grid/from_pw energy totals."""
+    try:
+        result = client.query(f'SHOW FIELD KEYS FROM "{retention_policy}"."{measurement}"')
+        return json.dumps(list(result.get_points()), indent=2, default=str)
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@mcp.tool()
+def query_powerwall(query: str) -> str:
+    """Execute an InfluxQL SELECT query against the Powerwall InfluxDB.
+
+    IMPORTANT — retention policies: unqualified tables only hit the default RP
+    ('autogen'). To read the real Powerwall data, qualify the table as
+    "rp".measurement. Examples:
+      SELECT * FROM "kwh".http ORDER BY time DESC LIMIT 10
+      SELECT mean("solar") FROM "autogen".http WHERE time >= now() - 1h GROUP BY time(5m)
+      SELECT "solar","home","to_grid","to_pw" FROM "daily".http ORDER BY time DESC LIMIT 7
+      SELECT * FROM "pod".http ORDER BY time DESC LIMIT 1   -- battery state
+      SELECT * FROM "vitals".http ORDER BY time DESC LIMIT 1  -- inverter vitals
+    Available RPs: autogen, raw, vitals, kwh, daily, grid, pod, alerts
+    (strings, pwtemps, monthly, fans are empty).
+    Only SELECT statements are allowed."""
+    if not query.strip().upper().startswith("SELECT"):
+        return "Error: Security exception. Only SELECT queries are allowed."
+    try:
+        result = client.query(query)
+        data = list(result.get_points())
+        return json.dumps(data, indent=2, default=str)
+    except Exception as e:
+        return f"Query Error: {str(e)}"
+
+
+def _run():
+    # streamable-http exposes the server at http://<host>:<port>/mcp
+    # This is the transport modern MCP clients/agents expect for a URL-based
+    # remote connection (replaces the older, now-deprecated SSE transport).
+    if not MCP_AUTH_TOKEN:
+        mcp.run(transport="streamable-http")
+        return
+
+    # Wrap the ASGI app with a simple bearer-token check so this isn't wide
+    # open to anyone who can reach the port. Required whenever this container
+    # is exposed beyond your own trusted LAN.
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class BearerAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            auth = request.headers.get("authorization", "")
+            if auth != f"Bearer {MCP_AUTH_TOKEN}":
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
+            return await call_next(request)
+
+    app = mcp.streamable_http_app()
+    app.add_middleware(BearerAuthMiddleware)
+    uvicorn.run(app, host=MCP_HOST, port=MCP_PORT)
+
+
+if __name__ == "__main__":
+    _run()

--- a/tools/powerwall-mcp/server.py
+++ b/tools/powerwall-mcp/server.py
@@ -33,8 +33,10 @@ without editing code:
                   Authorization: Bearer <token>
 """
 
+import hmac
 import json
 import os
+import re
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -62,6 +64,15 @@ _KNOWN_MEASUREMENTS = {
 
 # Cache for the expensive all-RP scan so repeated overview calls are instant.
 _OVERVIEW_CACHE = None
+
+# Identifiers we will interpolate into InfluxQL: bare word characters, dots
+# and hyphens. Anything else (quotes, semicolons, spaces, parens...) is
+# rejected so tool arguments can never break out of the quoted identifier.
+_IDENT_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$")
+
+
+def _safe_ident(name: str) -> bool:
+    return bool(name) and bool(_IDENT_RE.match(name))
 
 
 def _measurement_pool():
@@ -173,6 +184,11 @@ def get_field_keys(measurement: str, retention_policy: str = "autogen") -> str:
     to inspect those RPs. Returns [] if that RP has no data for the measurement.
     Useful fields: raw.http has the full 80-field Powerwall status; kwh.http and
     daily.http have solar/home/to_grid/to_pw/from_grid/from_pw energy totals."""
+    if not (_safe_ident(measurement) and _safe_ident(retention_policy)):
+        return (
+            "Error: Security exception. retention_policy and measurement must be "
+            "plain identifiers (letters, digits, '_', '-', '.')."
+        )
     try:
         result = client.query(f'SHOW FIELD KEYS FROM "{retention_policy}"."{measurement}"')
         return json.dumps(list(result.get_points()), indent=2, default=str)
@@ -195,10 +211,18 @@ def query_powerwall(query: str) -> str:
     Available RPs: autogen, raw, vitals, kwh, daily, grid, pod, alerts
     (strings, pwtemps, monthly, fans are empty).
     Only SELECT statements are allowed."""
-    if not query.strip().upper().startswith("SELECT"):
+    q = query.strip()
+    # Allow (and strip) trailing statement terminators, as agents often emit
+    # them; any remaining semicolon means multiple statements.
+    q = q.rstrip(";").rstrip()
+    if not q.upper().startswith("SELECT"):
         return "Error: Security exception. Only SELECT queries are allowed."
+    if ";" in q:
+        return "Error: Security exception. Multiple statements are not allowed."
+    if re.search(r"\bINTO\b", q, re.IGNORECASE):
+        return "Error: Security exception. SELECT ... INTO writes are not allowed."
     try:
-        result = client.query(query)
+        result = client.query(q)
         data = list(result.get_points())
         return json.dumps(data, indent=2, default=str)
     except Exception as e:
@@ -217,14 +241,15 @@ def _run():
     # open to anyone who can reach the port. Required whenever this container
     # is exposed beyond your own trusted LAN.
     import uvicorn
-    from starlette.applications import Starlette
     from starlette.responses import JSONResponse
     from starlette.middleware.base import BaseHTTPMiddleware
 
     class BearerAuthMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
             auth = request.headers.get("authorization", "")
-            if auth != f"Bearer {MCP_AUTH_TOKEN}":
+            expected = f"Bearer {MCP_AUTH_TOKEN}"
+            # Constant-time compare to avoid leaking the token via timing.
+            if not hmac.compare_digest(auth.encode(), expected.encode()):
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
             return await call_next(request)
 

--- a/tools/powerwall-mcp/test_server.py
+++ b/tools/powerwall-mcp/test_server.py
@@ -1,0 +1,144 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+class FakeFastMCP:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def tool(self):
+        return lambda function: function
+
+
+class FakeInfluxDBClient:
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+
+    def query(self, query):
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def load_server():
+    mcp_module = types.ModuleType("mcp")
+    mcp_server_module = types.ModuleType("mcp.server")
+    mcp_fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_module.FastMCP = FakeFastMCP
+    influxdb_module = types.ModuleType("influxdb")
+    influxdb_module.InfluxDBClient = FakeInfluxDBClient
+
+    modules = {
+        "mcp": mcp_module,
+        "mcp.server": mcp_server_module,
+        "mcp.server.fastmcp": mcp_fastmcp_module,
+        "influxdb": influxdb_module,
+    }
+    with patch.dict(sys.modules, modules):
+        path = Path(__file__).with_name("server.py")
+        spec = importlib.util.spec_from_file_location("powerwall_mcp_server", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+server = load_server()
+
+
+class QueryResult:
+    def __init__(self, points):
+        self.points = points
+
+    def get_points(self):
+        return iter(self.points)
+
+
+class ServerTests(unittest.TestCase):
+    def setUp(self):
+        server._OVERVIEW_CACHE = None
+        server._OVERVIEW_CACHE_TIME = 0.0
+
+    def test_client_has_request_timeout(self):
+        self.assertEqual(server.client.init_kwargs["timeout"], 30)
+
+    def test_overview_uses_field_keys_instead_of_point_tags(self):
+        client = Mock()
+
+        def query(query_text):
+            if query_text.startswith("SELECT"):
+                return QueryResult(
+                    [{"time": "2026-08-20T00:00:00Z", "solar": 5.0, "month": "08"}]
+                )
+            if query_text.startswith("SHOW FIELD KEYS"):
+                return QueryResult(
+                    [
+                        {"fieldKey": "solar", "fieldType": "float"},
+                        {"fieldKey": "home", "fieldType": "float"},
+                    ]
+                )
+            raise AssertionError(f"Unexpected query: {query_text}")
+
+        client.query.side_effect = query
+        with (
+            patch.object(server, "client", client),
+            patch.object(server, "_measurement_pool", return_value=["http"]),
+            patch.object(server, "_rps", return_value=["autogen"]),
+        ):
+            overview = server._build_overview()
+
+        self.assertEqual(overview["autogen"]["http"]["fields"], ["home", "solar"])
+        self.assertNotIn("month", overview["autogen"]["http"]["fields"])
+
+    def test_overview_cache_expires_and_can_be_refreshed(self):
+        build = Mock(side_effect=[{"version": 1}, {"version": 2}, {"version": 3}])
+        with (
+            patch.object(server, "_build_overview", build),
+            patch.object(server, "OVERVIEW_CACHE_TTL", 300),
+            patch.object(server.time, "monotonic", side_effect=[100, 200, 401, 402]),
+        ):
+            self.assertEqual(server._get_overview(), {"version": 1})
+            self.assertEqual(server._get_overview(), {"version": 1})
+            self.assertEqual(server._get_overview(), {"version": 2})
+            self.assertEqual(server._get_overview(force=True), {"version": 3})
+
+        self.assertEqual(build.call_count, 3)
+
+    def test_query_requires_a_bounded_limit(self):
+        self.assertIn(
+            "must end with a LIMIT",
+            server.query_powerwall('SELECT * FROM "autogen".http'),
+        )
+        self.assertIn(
+            "LIMIT must be between",
+            server.query_powerwall('SELECT * FROM "autogen".http LIMIT 1001'),
+        )
+        self.assertIn(
+            "must end with a LIMIT",
+            server.query_powerwall(
+                'SELECT * FROM "autogen".http WHERE "status" = \'LIMIT 10\''
+            ),
+        )
+        self.assertIn(
+            "comments are not allowed",
+            server.query_powerwall('SELECT * FROM "autogen".http -- LIMIT 10'),
+        )
+
+    def test_query_with_valid_limit_executes(self):
+        client = Mock()
+        client.query.return_value = QueryResult([{"solar": 5.0}])
+        with patch.object(server, "client", client):
+            response = server.query_powerwall(
+                'SELECT "solar" FROM "autogen".http LIMIT 10'
+            )
+
+        self.assertEqual(json.loads(response), [{"solar": 5.0}])
+        client.query.assert_called_once_with(
+            'SELECT "solar" FROM "autogen".http LIMIT 10'
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/powerwall-mcp/test_server.py
+++ b/tools/powerwall-mcp/test_server.py
@@ -27,6 +27,10 @@ def load_server():
     mcp_module = types.ModuleType("mcp")
     mcp_server_module = types.ModuleType("mcp.server")
     mcp_fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    # Mark stubs as packages so `from mcp.server.fastmcp import FastMCP` works
+    # on all Python versions (packages need a __path__ attribute).
+    mcp_module.__path__ = []
+    mcp_server_module.__path__ = []
     mcp_fastmcp_module.FastMCP = FakeFastMCP
     influxdb_module = types.ModuleType("influxdb")
     influxdb_module.InfluxDBClient = FakeInfluxDBClient


### PR DESCRIPTION
## Summary

Adds `tools/powerwall-mcp/` — an optional, self-contained MCP server that lets AI agents (Claude, Open WebUI, Hermes, etc.) query the dashboard's InfluxDB 1.8 data in plain language. Implements the proposal in #848.

**Why a dedicated server:** most InfluxDB MCP servers target v2/v3, and none know that the Telegraf exporter writes the *same measurement names into multiple retention policies* (`autogen`, `raw`, `vitals`, `kwh`, `daily`, `grid`, `pod`, `alerts`), each holding a different slice of data. This one does — that's the domain knowledge that makes agent answers correct.

## What's included

- `server.py` — MCP server (streamable HTTP transport), env-var configured, SELECT-only queries, optional bearer-token auth
- `Dockerfile` + `docker-compose.yml` — standalone stack (separate from the dashboard's compose; documented as such)
- `README.md` — setup, schema overview, examples

## Provenance / changes from upstream

Based on [ampersandru/powerwall-dashboard-mcp](https://github.com/ampersandru/powerwall-dashboard-mcp), offered for incorporation in #848 (thank you!). Changes made:

- Default `INFLUX_HOST` changed from a hardcoded LAN IP to `127.0.0.1`
- New README adapted to the `tools/` context, with attribution
- No functional code changes

**License:** @ampersandru has explicitly confirmed in this PR that the code is granted for use under the project's MIT license. Attribution to the upstream repo ([ampersandru/powerwall-dashboard-mcp](https://github.com/ampersandru/powerwall-dashboard-mcp)) is retained in the README.

Closes #848.

