### PR TITLE
ci: strict shellcheck (warning severity) for core scripts + fix real findings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,7 +52,8 @@ jobs:
           # command output, SC1090 dynamic env-file sourcing, SC2034 documented
           # placeholder vars, SC2063 cron glob-like regex.
           for file in add_route.sh anonymous-access.sh compose-dash.sh setup.sh \
-                      tz.sh upgrade.sh ver.sh verify.sh watchdog.sh weather.sh; do
+                      tz.sh upgrade.sh ver.sh verify.sh watchdog.sh weather.sh \
+                      backups/backup.sh.sample backups/restore.sh.sample; do
             shellcheck --shell=bash --severity=warning \
               --exclude=SC2068,SC2145,SC2046,SC1090,SC2034,SC2063 "$file"
           done

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,20 @@ jobs:
             shellcheck --shell=bash --severity=error --exclude=SC2068,SC2145 "$file"
           done < <(git ls-files -z '*.sh' '*.sh.sample')
 
+      - name: Run ShellCheck (strict, core scripts)
+        shell: bash
+        run: |
+          # Core scripts are held to warning-level severity so unquoted-variable
+          # bugs (SC2086-class) are caught before merge. Exclusions are intentional
+          # patterns: SC2068/SC2145 argument forwarding, SC2046 word-splitting of
+          # command output, SC1090 dynamic env-file sourcing, SC2034 documented
+          # placeholder vars, SC2063 cron glob-like regex.
+          for file in add_route.sh anonymous-access.sh compose-dash.sh setup.sh \
+                      tz.sh upgrade.sh ver.sh verify.sh watchdog.sh weather.sh; do
+            shellcheck --shell=bash --severity=warning \
+              --exclude=SC2068,SC2145,SC2046,SC1090,SC2034,SC2063 "$file"
+          done
+
   structured-data:
     name: JSON and YAML
     runs-on: ubuntu-latest

--- a/add_route.sh
+++ b/add_route.sh
@@ -97,7 +97,7 @@ if [[ "${OS}" == "Linux" ]]; then
         exit 1
     else
         echo "Native Linux detected"
-		if $(ip route | grep -qw ${LINUX_IP}); then
+		if ip route | grep -qw "${LINUX_IP}"; then
 			read -r -p "${LINUX_IP} routing already in routing table. Still want to run this? [y/N] " response
 			if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
 				echo "Cancel"

--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,7 @@ fi
 
 # Verify user in docker group (not required for Windows Git Bash)
 if ! type winpty > /dev/null 2>&1; then
-    if ! $(id -Gn 2>/dev/null | grep -qw "docker"); then
+    if ! id -Gn 2>/dev/null | grep -qw "docker"; then
         echo "WARNING: You do not appear to be in the docker group."
         echo ""
         echo "Please ensure your local user is in the docker group and run without sudo."
@@ -76,8 +76,9 @@ fi
 running() {
     local url=${1:-http://localhost:80}
     local code=${2:-200}
-    local status=$(curl --head --location --connect-timeout 5 --write-out %{http_code} --silent --output /dev/null ${url})
-    [[ $status == ${code} ]]
+    local status
+    status=$(curl --head --location --connect-timeout 5 --write-out '%{http_code}' --silent --output /dev/null "${url}")
+    [[ $status == "${code}" ]]
 }
 
 # Docker Dependency Check
@@ -685,14 +686,14 @@ if [ "${LAT}" == "zzLAT" ] || [ "${LONG}" == "zzLONG" ] || [ "${LAT}" == "0.0" ]
     if PYTHON=$(command -v python3 || command -v python); then
         if IP_RESPONSE=$(curl -s -L --fail https://freeipapi.com/api/json); then
             # Try to parse JSON but catch any errors
-            read LAT LONG <<< $(printf '%s' "$IP_RESPONSE" | "${PYTHON}" -c '
+            read LAT LONG <<< "$(printf '%s' "$IP_RESPONSE" | "${PYTHON}" -c '
 import sys, json
 try:
     data = json.load(sys.stdin)
     print(data["latitude"], data["longitude"])
 except Exception:
     print("0.0", "0.0")
-')
+')"
         fi
     fi
 else
@@ -771,7 +772,7 @@ if [ "${config}" == "Tesla Cloud" ]; then
     echo ""
     echo "Once you have the token, paste it when prompted by the setup below."
     echo "-----------------------------------------"
-    docker exec -it pypowerwall python3 -m pypowerwall setup -email=$(grep -E "^PW_EMAIL=.+" "${PW_ENV_FILE}" | cut -d= -f2)
+    docker exec -it pypowerwall python3 -m pypowerwall setup "-email=$(grep -E "^PW_EMAIL=.+" "${PW_ENV_FILE}" | cut -d= -f2)"
     echo "Restarting..."
     docker restart pypowerwall
     echo "-----------------------------------------"

--- a/setup.sh
+++ b/setup.sh
@@ -772,7 +772,7 @@ if [ "${config}" == "Tesla Cloud" ]; then
     echo ""
     echo "Once you have the token, paste it when prompted by the setup below."
     echo "-----------------------------------------"
-    docker exec -it pypowerwall python3 -m pypowerwall setup "-email=$(grep -E "^PW_EMAIL=.+" "${PW_ENV_FILE}" | cut -d= -f2)"
+    docker exec -it pypowerwall python3 -m pypowerwall setup "-email=$(grep -E '^PW_EMAIL=.+' "${PW_ENV_FILE}" | cut -d= -f2)"
     echo "Restarting..."
     docker restart pypowerwall
     echo "-----------------------------------------"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -38,16 +38,18 @@ fi
 running() {
     local url=${1:-http://localhost:80}
     local code=${2:-200}
-    local status=$(curl --head --location --connect-timeout 5 --write-out %{http_code} --silent --output /dev/null ${url})
-    [[ $status == ${code} ]]
+    local status
+    status=$(curl --head --location --connect-timeout 5 --write-out '%{http_code}' --silent --output /dev/null "${url}")
+    [[ $status == "${code}" ]]
 }
 
 # Compare semantic versions: returns 0 if $1 < $2
 version_lt() {
     local IFS=.
     local i
-    local ver1=($1)
-    local ver2=($2)
+    local ver1 ver2
+    read -r -a ver1 <<< "$1"
+    read -r -a ver2 <<< "$2"
     for ((i=0;i<3;i++)); do
         local a=${ver1[i]:-0}
         local b=${ver2[i]:-0}

--- a/verify.sh
+++ b/verify.sh
@@ -30,7 +30,8 @@ detect_light_background() {
         # Method 1: Try to query terminal background color (non-macOS only)
         if [[ -t 1 ]]; then
             # Save current terminal settings
-            local oldstty=$(stty -g 2>/dev/null) || return 1
+            local oldstty
+            oldstty=$(stty -g 2>/dev/null) || return 1
 
             # Set up a trap to ensure terminal settings are restored
             trap 'stty "$oldstty" 2>/dev/null || true; trap - RETURN' RETURN
@@ -256,8 +257,9 @@ running() {
     else
         head=""
     fi
-    local status=$(curl ${head} -k --location --connect-timeout 5 --write-out %{http_code} --silent --output /dev/null ${url})
-    [[ $status == ${code} ]]
+    local status
+    status=$(curl "${head}" -k --location --connect-timeout 5 --write-out '%{http_code}' --silent --output /dev/null "${url}")
+    [[ $status == "${code}" ]]
 }
 
 # Operating system details

--- a/verify.sh
+++ b/verify.sh
@@ -252,13 +252,12 @@ fi
 running() {
     local url=${1:-http://localhost:80}
     local code=${2:-200}
+    local -a head_args=()
     if [[ $3 == 1 ]]; then
-        head="--head"
-    else
-        head=""
+        head_args=(--head)
     fi
     local status
-    status=$(curl "${head}" -k --location --connect-timeout 5 --write-out '%{http_code}' --silent --output /dev/null "${url}")
+    status=$(curl "${head_args[@]}" -k --location --connect-timeout 5 --write-out '%{http_code}' --silent --output /dev/null "${url}")
     [[ $status == "${code}" ]]
 }
 

--- a/weather.sh
+++ b/weather.sh
@@ -33,14 +33,14 @@ else
     if PYTHON=$(command -v python3 || command -v python); then
         if IP_RESPONSE=$(curl -s -L --fail https://freeipapi.com/api/json); then
             # Try to parse JSON but catch any errors
-            read LAT LONG <<< $(printf '%s' "$IP_RESPONSE" | "${PYTHON}" -c '
+            read LAT LONG <<< "$(printf '%s' "$IP_RESPONSE" | "${PYTHON}" -c '
 import sys, json
 try:
     data = json.load(sys.stdin)
     print(data["latitude"], data["longitude"])
 except Exception:
     print("0.0", "0.0")
-')
+')"
         fi
     fi
 fi


### PR DESCRIPTION
Follow-up to the `shellcheck` discussion in #860 — @jasonacox asked for this as a CI addition, tested locally.

**What's here**

The repo already had shellcheck in CI (`.github/workflows/validate.yml`, added in d4a1ae5) — but at `--severity=error`, which does **not** catch the SC2086-class unquoted-variable bug that #860 fixes (SC2086 is `info`/`warning` severity). So this PR raises the bar: the core scripts (`setup.sh`, `upgrade.sh`, `verify.sh`, `add_route.sh`, `compose-dash.sh`, `weather.sh`, `tz.sh`, `ver.sh`, `watchdog.sh`, `anonymous-access.sh`) are now checked at **`--severity=warning`**. The whole-repo error-level check is unchanged.

**Real bugs the strict pass caught** (all fixed here):

- **`setup.sh`** — `if ! $(id -Gn | grep -qw "docker")` executed the (empty) output of `grep -q`, so the "not in docker group" warning was **dead code that could never fire** (SC2091). Now actually checks the group membership.
- **`add_route.sh`** — same pattern: `if $(ip route | grep -qw ${LINUX_IP})` always executed an empty command (status 0), so the "routing already in routing table" prompt fired **regardless of whether the route existed** (SC2091). Now checks the route for real.
- **`setup.sh` / `upgrade.sh` / `verify.sh`** — `local status=$(curl ...)` masked return values (SC2155); `--write-out %{http_code}` unquoted (SC1083); `${head}`/`${url}` unquoted in `verify.sh`.
- **`upgrade.sh`** — `version_lt()` used unquoted array assignment (SC2206); rewritten with `read -r -a` — **behavior verified locally** with an 8-case test harness (10 > 9, 5.2 < 5.2.1, equal versions, etc.), all pass.
- **`setup.sh` / `weather.sh`** — unquoted `$(...)` feeding `read LAT LONG` (SC2046).
- **`verify.sh`** — quote the right-hand side of `[[ $status == ${code} ]]` (SC2053).

**Exclusions (documented in the workflow):** `SC2068`/`SC2145` (existing argument-forwarding patterns), `SC2046` where word-splitting is intentional (`docker stop $(docker ps -aq)`), `SC1090` (dynamic `. env` file sourcing), `SC2034` (documented placeholder vars), `SC2063` (cron `*/5` glob-like regex).

**Testing done locally:**
- shellcheck v0.10.0: core scripts clean at `--severity=warning` with the documented excludes; whole repo still clean at `--severity=error`
- `bash -n` passes on all touched scripts
- `version_lt()` rewritten function: 8/8 test cases pass
- workflow YAML validated

Note: `upgrade.sh` will have a trivial merge conflict with #860 (both touch nearby regions) — happy to rebase once that merges.

Not for the changelog — CI hardening plus bug fixes with no user-visible behavior change beyond the two revived warnings/prompt firing as originally intended.

— Sam 🌊