### PR TITLE
Fix verify.sh tedapi_mode parsing for spaced JSON

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -332,7 +332,7 @@ tedapi_diagnostics() {
         local cloudmode tedapi tedapimode firmware
         cloudmode=$(echo "$proxy_stats" | grep -o '"cloudmode":[^,}]*' | cut -d: -f2 | tr -d ' ')
         tedapi=$(echo "$proxy_stats" | grep -o '"tedapi":[^,}]*' | cut -d: -f2 | tr -d ' ')
-        tedapimode=$(echo "$proxy_stats" | grep -o '"tedapi_mode":"[^"]*"' | cut -d\" -f4)
+        tedapimode=$(echo "$proxy_stats" | grep -o '"tedapi_mode"[: ]*"[^"]*"' | cut -d\" -f4)
         firmware=$(curl --silent --connect-timeout 3 http://localhost:8675/version 2>/dev/null | sed 's/.*"version"[: ]*"\([^"]*\)".*/\1/') || true
         echo -e "${dim} - pypowerwall proxy: ${subbold}running${dim} - cloudmode: ${subbold}${cloudmode:-unknown}${dim}, tedapi: ${subbold}${tedapi:-unknown}${dim}, tedapi_mode: ${subbold}${tedapimode:-unknown}"
         if [ -n "$firmware" ]; then
@@ -621,7 +621,7 @@ if [ "$HOST" != "localhost" ] || [ "$RUNNING" = "true" ]; then
         # Extract tedapi
         TEDAPI=`echo "$STATS_JSON" | grep -o '"tedapi":[^,}]*' | cut -d: -f 2 | tr -d ' ' 2>/dev/null`
         # Extract tedapi_mode
-        TEDAPIMODE=`echo "$STATS_JSON" | grep -o '"tedapi_mode":"[^"]*"' | cut -d\" -f 4 2>/dev/null`
+        TEDAPIMODE=`echo "$STATS_JSON" | grep -o '"tedapi_mode"[: ]*"[^"]*"' | cut -d\" -f 4 2>/dev/null`
         # check connection with powerwall
         if running http://$HOST:$PORT/version 200 0 2>/dev/null; then
             PWSTATE="CONNECTED"


### PR DESCRIPTION
## Problem

As diagnosed in #862, `verify.sh` always reports `tedapi_mode: unknown` even when the proxy is running in v1r mode.

## Root cause

The pypowerwall proxy serves `/stats` via `json.dumps()`, which emits a space after the colon:

```json
"tedapi_mode": "v1r"
```

But both extraction sites in `verify.sh` used a strict compact-only grep pattern:

```bash
grep -o '"tedapi_mode":"[^"]*"'
```

which never matches, so the `unknown` fallback always printed. The neighboring `cloudmode` pattern (`"cloudmode"[: ]*[^,}]*`) already handled optional whitespace — `tedapi_mode` was the odd one out.

## Fix

Allow optional whitespace (`[: ]*`) in the pattern at both sites:

- the `--tedapi` diagnostics section
- the main-flow pypowerwall status line

## Testing

Tested extraction against both JSON forms:

- spaced: `{"tedapi_mode": "v1r"}` → `v1r` ✅ (old pattern: empty → `unknown`)
- compact: `{"tedapi_mode":"full"}` → `full` ✅
- `bash -n verify.sh` clean

Fixes #862
